### PR TITLE
CPedPath complete

### DIFF
--- a/src/control/PathFind.cpp
+++ b/src/control/PathFind.cpp
@@ -36,10 +36,10 @@ CPedPath::CalcPedRoute(int8 pathType, CVector position, CVector destination, CVe
 	CVector vecPos = (position + destination) * 0.5f;
 	CVector vecSectorStartPos (vecPos.x - 14.0f, vecPos.y - 14.0f, vecPos.z);
 	CVector2D vecSectorEndPos (vecPos.x + 28.0f, vecPos.x + 28.0f);
-	const int16 nodeStartX = (position.x - vecSectorStartPos.x) * 1.4286f;
-	const int16 nodeStartY = (position.y - vecSectorStartPos.y) * 1.4286f;
-	const int16 nodeEndX = (destination.x - vecSectorStartPos.x) * 1.4286f;
-	const int16 nodeEndY = (destination.y - vecSectorStartPos.y) * 1.4286f;
+	const int16 nodeStartX = (position.x - vecSectorStartPos.x) / 0.7f;
+	const int16 nodeStartY = (position.y - vecSectorStartPos.y) / 0.7f;
+	const int16 nodeEndX = (destination.x - vecSectorStartPos.x) / 0.7f;
+	const int16 nodeEndY = (destination.y - vecSectorStartPos.y) / 0.7f;
 	if (nodeStartX == nodeEndX && nodeStartY == nodeEndY)
 		return false;
 	CPedPathNode pathNodes[40][40]; 
@@ -119,38 +119,22 @@ CPedPath::CalcPedRoute(int8 pathType, CVector position, CVector destination, CVe
 	for (*pointsFound = 0; pPathNode != pEndPathNode && *pointsFound < maxPoints; ++ *pointsFound) {
 		const uint8 nodeIdX = pPathNode->nodeIdX;
 		const uint8 nodeIdY = pPathNode->nodeIdY;
-		if (nodeIdX <= 0 || pathNodes[nodeIdX - 1][nodeIdY].id + 5 != pPathNode->id) {
-			if (nodeIdX >= 39 || pathNodes[nodeIdX + 1][nodeIdY].id + 5 != pPathNode->id) {
-				if (nodeIdY <= 0 || pathNodes[nodeIdX][nodeIdY - 1].id + 5 != pPathNode->id) {
-					if (nodeIdY >= 39 || pathNodes[nodeIdX][nodeIdY + 1].id + 5 != pPathNode->id) {
-						if (nodeIdX <= 0 || nodeIdY <= 0 || pathNodes[nodeIdX - 1][nodeIdY - 1].id + 7 != pPathNode->id) {
-							if (nodeIdX <= 0 || nodeIdY >= 39 || pathNodes[nodeIdX - 1][nodeIdY + 1].id + 7 != pPathNode->id) {
-								if (nodeIdX >= 39 || nodeIdY <= 0 || pathNodes[nodeIdX + 1][nodeIdY - 1].id + 7 != pPathNode->id) {
-									if (nodeIdX < 39 && nodeIdY < 39 && pathNodes[nodeIdX + 1][nodeIdY + 1].id + 7 == pPathNode->id)
-										pPathNode = &pathNodes[nodeIdX + 1][nodeIdY + 1];
-								} else {
-									pPathNode = &pathNodes[nodeIdX + 1][nodeIdY - 1];
-								}
-							} else {
-								pPathNode = &pathNodes[nodeIdX - 1][nodeIdY + 1];
-							}
-						} else {
-							pPathNode = &pathNodes[nodeIdX - 1][nodeIdY - 1];
-						}
-					} else {
-						pPathNode = &pathNodes[nodeIdX][nodeIdY + 1]; 
-					}
-				} else {
-					pPathNode = &pathNodes[nodeIdX][nodeIdY - 1]; 
-				}
-			}
-			else {
-				pPathNode = &pathNodes[nodeIdX + 1][nodeIdY];
-			}
-		}
-		else {
-			pPathNode = &pathNodes[nodeIdX - 1][nodeIdY]; 
-		}
+		if (nodeIdX > 0 && pathNodes[nodeIdX - 1][nodeIdY].id + 5 == pPathNode->id) 
+			pPathNode = &pathNodes[nodeIdX - 1][nodeIdY];
+		else if (nodeIdX > 39 && pathNodes[nodeIdX + 1][nodeIdY].id + 5 == pPathNode->id)
+			pPathNode = &pathNodes[nodeIdX + 1][nodeIdY];
+		else if (nodeIdY > 0 && pathNodes[nodeIdX][nodeIdY - 1].id + 5 == pPathNode->id) 
+			pPathNode = &pathNodes[nodeIdX][nodeIdY - 1];
+		else if (nodeIdY > 39 && pathNodes[nodeIdX][nodeIdY + 1].id + 5 == pPathNode->id) 
+			pPathNode = &pathNodes[nodeIdX][nodeIdY + 1];
+		else if (nodeIdX > 0 && nodeIdY > 0 && pathNodes[nodeIdX - 1][nodeIdY - 1].id + 7 == pPathNode->id)
+			pPathNode = &pathNodes[nodeIdX - 1][nodeIdY - 1];
+		else if (nodeIdX > 0 && nodeIdY < 39 && pathNodes[nodeIdX - 1][nodeIdY + 1].id + 7 == pPathNode->id)
+			pPathNode = &pathNodes[nodeIdX - 1][nodeIdY + 1];
+		else if (nodeIdX < 39 && nodeIdY > 0 && pathNodes[nodeIdX + 1][nodeIdY - 1].id + 7 == pPathNode->id)
+			pPathNode = &pathNodes[nodeIdX + 1][nodeIdY - 1];
+		else if (nodeIdX < 39 && nodeIdY < 39 && pathNodes[nodeIdX + 1][nodeIdY + 1].id + 7 == pPathNode->id)
+			pPathNode = &pathNodes[nodeIdX + 1][nodeIdY + 1];
 		pointPoses[*pointsFound] = vecSectorStartPos;
 		pointPoses[*pointsFound].x += (float)pPathNode->nodeIdX * 0.7f;
 		pointPoses[*pointsFound].y += (float)pPathNode->nodeIdY * 0.7f;

--- a/src/control/PathFind.cpp
+++ b/src/control/PathFind.cpp
@@ -15,6 +15,7 @@ bool gbShowCarPathsLinks;
 CPathFind &ThePaths = *(CPathFind*)0x8F6754;
 
 #define MAX_DIST INT16_MAX-1
+#define MIN_PED_ROUTE_DISTANCE 23.8f
 
 // object flags:
 //	1	UseInRoadBlock
@@ -31,7 +32,7 @@ CPedPath::CalcPedRoute(int8 pathType, CVector position, CVector destination, CVe
 {
 	*pointsFound = 0;
 	CVector vecDistance = destination - position;
-	if (Abs(vecDistance.x) > 23.8f || Abs(vecDistance.y) > 23.8f || Abs(vecDistance.z) > 23.8f)
+	if (Abs(vecDistance.x) > MIN_PED_ROUTE_DISTANCE || Abs(vecDistance.y) > MIN_PED_ROUTE_DISTANCE || Abs(vecDistance.z) > MIN_PED_ROUTE_DISTANCE)
 		return false;
 	CVector vecPos = (position + destination) * 0.5f;
 	CVector vecSectorStartPos (vecPos.x - 14.0f, vecPos.y - 14.0f, vecPos.z);
@@ -47,7 +48,7 @@ CPedPath::CalcPedRoute(int8 pathType, CVector position, CVector destination, CVe
 	for (int32 x = 0; x < 40; x++) {
 		for (int32 y = 0; y < 40; y++) {
 			pathNodes[x][y].bBlockade = false;
-			pathNodes[x][y].id = 0x7FFF;
+			pathNodes[x][y].id = INT16_MAX;
 			pathNodes[x][y].nodeIdX = x;
 			pathNodes[x][y].nodeIdY = y;
 		}
@@ -147,7 +148,7 @@ void
 CPedPath::AddNodeToPathList(CPedPathNode *pNodeToAdd, int16 id, CPedPathNode *pNodeList) 
 {
 	if (!pNodeToAdd->bBlockade && id < pNodeToAdd->id) {
-		if (pNodeToAdd->id != 0x7FFF)
+		if (pNodeToAdd->id != INT16_MAX)
 			RemoveNodeFromList(pNodeToAdd);
 		AddNodeToList(pNodeToAdd, id, pNodeList);
 	}

--- a/src/control/PathFind.cpp
+++ b/src/control/PathFind.cpp
@@ -136,8 +136,8 @@ CPedPath::CalcPedRoute(int8 pathType, CVector position, CVector destination, CVe
 		else if (nodeIdX < 39 && nodeIdY < 39 && pathNodes[nodeIdX + 1][nodeIdY + 1].id + 7 == pPathNode->id)
 			pPathNode = &pathNodes[nodeIdX + 1][nodeIdY + 1];
 		pointPoses[*pointsFound] = vecSectorStartPos;
-		pointPoses[*pointsFound].x += (float)pPathNode->nodeIdX * 0.7f;
-		pointPoses[*pointsFound].y += (float)pPathNode->nodeIdY * 0.7f;
+		pointPoses[*pointsFound].x += pPathNode->nodeIdX * 0.7f;
+		pointPoses[*pointsFound].y += pPathNode->nodeIdY * 0.7f;
 	}
 	return true;
 }
@@ -203,10 +203,10 @@ CPedPath::AddBlockade(CEntity *pEntity, CPedPathNode(*pathNodes)[40], CVector *p
 		vecBoundCentre.x - fBoundRadius <= pPosition->x + 28.0f &&
 		vecBoundCentre.y - fBoundRadius <= pPosition->y + 28.0f) {
 		for (int16 x = 0; x < 40; x++) {
-			const float pointX = (float)x * 0.7f + fDistanceX;
+			const float pointX = x * 0.7f + fDistanceX;
 			for (int16 y = 0; y < 40; y++) {
 				if (!pathNodes[x][y].bBlockade) {
-					const float pointY = (float)y * 0.7f + fDistanceY;
+					const float pointY = y * 0.7f + fDistanceY;
 					CVector2D point(pointX, pointY);
 					if (fBoundMaxX > Abs(DotProduct2D(point, pEntity->m_matrix.GetRight()))) {
 						float fDotProduct = DotProduct2D(point, pEntity->m_matrix.GetForward());

--- a/src/control/PathFind.h
+++ b/src/control/PathFind.h
@@ -3,11 +3,7 @@
 #include "Treadable.h"
 
 class CVehicle;
-
-class CPedPath {
-public:
-	static bool CalcPedRoute(uint8, CVector, CVector, CVector*, int16*, int16);
-};
+class CPtrList;
 
 enum
 {
@@ -28,6 +24,33 @@ enum
 {
 	SWITCH_OFF = 0,
 	SWITCH_ON = 1,
+};
+
+enum 
+{
+	ROUTE_ADD_BLOCKADE = 0,
+	ROUTE_NO_BLOCKADE = 1
+};
+
+struct CPedPathNode
+{
+	bool bBlockade;
+	uint8 nodeIdX;
+	uint8 nodeIdY;
+	int16 id;
+	CPedPathNode* prev;
+	CPedPathNode* next;
+};
+static_assert(sizeof(CPedPathNode) == 0x10, "CPedPathNode: error");
+
+class CPedPath {
+public:
+	static bool CalcPedRoute(int8 pathType, CVector position, CVector destination, CVector *pointPoses, int16 *pointsFound, int16 maxPoints);
+	static void AddNodeToPathList(CPedPathNode *pNodeToAdd, int16 id, CPedPathNode *pNodeList);
+	static void RemoveNodeFromList(CPedPathNode *pNode);
+	static void AddNodeToList(CPedPathNode *pNode, int16 index, CPedPathNode *pList);
+	static void AddBlockade(CEntity *pEntity, CPedPathNode(*pathNodes)[40], CVector *pPosition);
+	static void AddBlockadeSectorList(CPtrList& list, CPedPathNode(*pathNodes)[40], CVector *pPosition);
 };
 
 struct CPathNode


### PR DESCRIPTION
This is an unused function. There is an opcode for it, but I confirmed that it's not being used. I tested the code. It works, or at least it behaves the same way as the original function. I also tried calling the original function from memory and saw how this function affects the ped. If the point is closer to the ped, then the ped starts moving towards the point and after a while the ped starts moving in a different direction. floating-point comparisons were completely messed up in `CPedPath::AddBlockade`, I used the android IDB and ghidra to fix it. 
