### PR TITLE
Hide Vehicle/Zone name during Wasted/Busted...

### DIFF
--- a/src/core/Frontend.cpp
+++ b/src/core/Frontend.cpp
@@ -305,9 +305,11 @@ ScaleAndCenterX(float x)
 	} while(0)
 
 #define ProcessRadioIcon(sprite, x, y, radioId, hoverOpt) \
-	sprite.Draw(x, y, MENU_X(MENURADIO_ICON_SCALE), MENU_Y(MENURADIO_ICON_SCALE), radioId == m_PrefsRadioStation ? CRGBA(255, 255, 255, 255) : CRGBA(225, 0, 0, 170)); \
-		if (CheckHover(x, x + MENU_X(MENURADIO_ICON_SCALE), y, y + MENU_Y(MENURADIO_ICON_SCALE))) \
-			m_nHoverOption = hoverOpt;
+	do { \
+		sprite.Draw(x, y, MENU_X(MENURADIO_ICON_SCALE), MENU_Y(MENURADIO_ICON_SCALE), radioId == m_PrefsRadioStation ? CRGBA(255, 255, 255, 255) : CRGBA(225, 0, 0, 170)); \
+			if (CheckHover(x, x + MENU_X(MENURADIO_ICON_SCALE), y, y + MENU_Y(MENURADIO_ICON_SCALE))) \
+				m_nHoverOption = hoverOpt; \
+	} while (0)
 
 // --- Functions not in the game/inlined starts
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -208,6 +208,7 @@ enum Config {
 #define SCROLLABLE_STATS_PAGE	// only draggable by mouse atm
 #define TRIANGLE_BACK_BUTTON
 // #define CIRCLE_BACK_BUTTON
+#define HUD_ENHANCEMENTS	// Adjusts some aspects to make the HUD look/behave a little bit better. 
 
 // Script
 #define USE_DEBUG_SCRIPT_LOADER	// makes game load main_freeroam.scm by default

--- a/src/render/Hud.cpp
+++ b/src/render/Hud.cpp
@@ -473,7 +473,12 @@ void CHud::Draw()
 					break;
 
 				}
+
+#ifndef HUD_ENHANCEMENTS
 				if (!m_Message[0]) {
+#else
+				if (!m_Message[0] && !m_BigMessage[2][0]) { // Hide zone name if wasted/busted text is displaying
+#endif
 					m_ZoneNameTimer += CTimer::GetTimeStepInMilliseconds();
 					CFont::SetJustifyOff();
 					CFont::SetPropOn();
@@ -563,7 +568,11 @@ void CHud::Draw()
 					break;
 				}
 
+#ifndef HUD_ENHANCEMENTS
 				if (!m_Message[0]) {
+#else
+				if (!m_Message[0] && !m_BigMessage[2][0]) { // Hide vehicle name if wasted/busted text is displaying
+#endif
 					m_VehicleNameTimer += CTimer::GetTimeStepInMilliseconds();
 					CFont::SetJustifyOff();
 					CFont::SetPropOn();


### PR DESCRIPTION
Fixed little mistake in my latest commit.