### PR TITLE
fix premake failing if not passing any action (such as with --help)

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -196,5 +196,5 @@ project "re3"
 		
 	filter "platforms:*gl3_glfw*"
 		libdirs { path.join(_OPTIONS["glewdir"], "lib/Release/Win32") }
-		libdirs { path.join(_OPTIONS["glfwdir"], "lib-" .. string.gsub(_ACTION, "vs", "vc")) }
+		libdirs { path.join(_OPTIONS["glfwdir"], "lib-" .. string.gsub(_ACTION or '', "vs", "vc")) }
 		links { "opengl32", "glew32s", "glfw3" }


### PR DESCRIPTION
Fixes the following error when running `premake5 --help`:

```
Error: X:/re3/source/premake5.lua:199: bad argument #1 to 'gsub' (string expected, got nil)
```