### PR TITLE
Call CWorld::Remove before the delete

### DIFF
--- a/src/peds/Population.cpp
+++ b/src/peds/Population.cpp
@@ -117,8 +117,7 @@ CPopulation::Initialise()
 void
 CPopulation::RemovePed(CPed *ent)
 {
-	// CPed dtor already does that
-	// CWorld::Remove((CEntity*)ent);
+	CWorld::Remove((CEntity*)ent);
 	delete ent;
 }
 


### PR DESCRIPTION
The original game does this and its safer. I don't like relying on the destructor to CWorld::Remove, I feel like R* would have asserted in that case or done it in the case of a last resort.