### PR TITLE
Fix small logic mistake in CGarage::RemoveCarsBlockingDoorNotInside

### DIFF
--- a/src/control/Garages.cpp
+++ b/src/control/Garages.cpp
@@ -1384,7 +1384,7 @@ void CGarage::RemoveCarsBlockingDoorNotInside()
 		if (pVehicle->GetPosition().x < m_fX1 || pVehicle->GetPosition().x > m_fX2 ||
 			pVehicle->GetPosition().y < m_fY1 || pVehicle->GetPosition().y > m_fY2 ||
 			pVehicle->GetPosition().z < m_fZ1 || pVehicle->GetPosition().z > m_fZ2) {
-			if (pVehicle->bIsLocked && pVehicle->CanBeDeleted()) {
+			if (!pVehicle->bIsLocked && pVehicle->CanBeDeleted()) {
 				CWorld::Remove(pVehicle);
 				delete pVehicle;
 				return; // WHY?


### PR DESCRIPTION
The issue is you need to check !bIsLocked, the logic re3 has excludes every car basically. Check 0x4262A8 in gta3 v1.1 if you need to confirm.