### PR TITLE
CREATE_RANDOM_CAR_FOR_CAR_PARK is supposed to be RANDOM_VEHICLE

### DIFF
--- a/src/control/Script.cpp
+++ b/src/control/Script.cpp
@@ -9700,7 +9700,7 @@ int8 CRunningScript::ProcessCommands900To999(int32 command)
 			return 0;
 		CVehicle* car;
 		if (!CModelInfo::IsBikeModel(model))
-			car = new CAutomobile(model, MISSION_VEHICLE);
+			car = new CAutomobile(model, RANDOM_VEHICLE);
 		CVector pos = *(CVector*)&ScriptParams[0];
 		pos.z += car->GetDistanceFromCentreOfMassToBaseOfModel();
 		car->SetPosition(pos);


### PR DESCRIPTION
As it says in the title. Creating parked cars using this command in re3, they never disappear and save into save games...