### PR TITLE
Added bug fix to fix mission related crashes

### DIFF
--- a/src/control/CarCtrl.cpp
+++ b/src/control/CarCtrl.cpp
@@ -726,6 +726,10 @@ CCarCtrl::RemoveDistantCars()
 void
 CCarCtrl::PossiblyRemoveVehicle(CVehicle* pVehicle)
 {
+#ifdef FIX_BUGS
+	if (pVehicle->bIsLocked)
+		return;
+#endif
 	CVector vecPlayerPos = FindPlayerCentreOfWorld(CWorld::PlayerInFocus);
 	/* BUG: this variable is initialized only in if-block below but can be used outside of it. */
 	if (!IsThisVehicleInteresting(pVehicle) && !pVehicle->bIsLocked &&


### PR DESCRIPTION
The original game sets bIsLocked to true if it wants that vehicle to stick around. It's set to true on the trains and planes always and also on mission vehicles until their no longer needed. This FIX_BUGS check fixes some crashes I've observed in the El Burro race regarding pushing cars into water because you can cause them to get deleted at just the wrong time. This solves the issues with the minor difference of the blown up vehicles sticking round until the mission is over.