### PR TITLE
Fixes for Wayland (HiDPI and mouse lock) support, FreeBSD

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -82,7 +82,10 @@ workspace "re3"
 
 	filter { "system:bsd" }
 		platforms {
-			"bsd-amd64-librw_gl3_glfw-oal"
+			"bsd-x86-librw_gl3_glfw-oal",
+			"bsd-amd64-librw_gl3_glfw-oal",
+			"bsd-arm-librw_gl3_glfw-oal",
+			"bsd-arm64-librw_gl3_glfw-oal"
 		}
 
 	filter "configurations:Debug"

--- a/src/skel/glfw/glfw.cpp
+++ b/src/skel/glfw/glfw.cpp
@@ -1397,8 +1397,11 @@ _InputTranslateShiftKeyUpDown(RsKeyCodes *rs) {
 // TODO this only works in frontend(and luckily only frontend use this). Fun fact: if I get pos manually in game, glfw reports that it's > 32000
 void
 cursorCB(GLFWwindow* window, double xpos, double ypos) {
-	FrontEndMenuManager.m_nMouseTempPosX = xpos;
-	FrontEndMenuManager.m_nMouseTempPosY = ypos;
+	int bufw, bufh, winw, winh;
+	glfwGetWindowSize(window, &winw, &winh);
+	glfwGetFramebufferSize(window, &bufw, &bufh);
+	FrontEndMenuManager.m_nMouseTempPosX = xpos * (bufw / winw);
+	FrontEndMenuManager.m_nMouseTempPosY = ypos * (bufh / winh);
 }
 
 void

--- a/src/skel/glfw/glfw.cpp
+++ b/src/skel/glfw/glfw.cpp
@@ -1628,6 +1628,8 @@ main(int argc, char *argv[])
 #endif
 		{
 			glfwPollEvents();
+			glfwSetInputMode(PSGLOBAL(window), GLFW_CURSOR,
+			                 (FrontEndMenuManager.m_bMenuActive && !PSGLOBAL(fullScreen)) ? GLFW_CURSOR_HIDDEN : GLFW_CURSOR_DISABLED);
 			if( ForegroundApp )
 			{
 				switch ( gGameState )

--- a/src/skel/glfw/glfw.cpp
+++ b/src/skel/glfw/glfw.cpp
@@ -235,8 +235,10 @@ double
 psTimer(void)
 {
 	struct timespec start; 
-#ifdef __linux__
+#if defined(CLOCK_MONOTONIC_RAW)
 	clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+#elif defined(CLOCK_MONOTONIC_FAST)
+	clock_gettime(CLOCK_MONOTONIC_FAST, &start);
 #else
 	clock_gettime(CLOCK_MONOTONIC, &start);
 #endif

--- a/src/skel/glfw/glfw.cpp
+++ b/src/skel/glfw/glfw.cpp
@@ -881,7 +881,7 @@ void psPostRWinit(void)
 	RwEngineGetVideoModeInfo(&vm, GcurSelVM);
 
 	glfwSetKeyCallback(PSGLOBAL(window), keypressCB);
-	glfwSetWindowSizeCallback(PSGLOBAL(window), resizeCB);
+	glfwSetFramebufferSizeCallback(PSGLOBAL(window), resizeCB);
 	glfwSetScrollCallback(PSGLOBAL(window), scrollCB);
 	glfwSetCursorPosCallback(PSGLOBAL(window), cursorCB);
 	glfwSetCursorEnterCallback(PSGLOBAL(window), cursorEnterCB);


### PR DESCRIPTION
This PR:

- Fixes HiDPI support on Wayland (will fix on macOS too when someone does macOS support) by using framebuffer size, not window size (the latter is in logical pixels, not real GL pixels)
  - merge together with librw PR: https://github.com/aap/librw/pull/35
- Fixes mouse lock on Wayland (you can't just warp the mouse to the center, let GLFW handle it)
- Adds more architectures to `bsd` build (I'll test on arm64 soon)
- Adds `CLOCK_MONOTONIC_FAST` usage
- needs testing on other platforms to make sure nothing is broken of course :)