### PR TITLE
Fix some sanitizer errors, improve POSIX streamer

### DIFF
--- a/src/control/Garages.cpp
+++ b/src/control/Garages.cpp
@@ -1509,7 +1509,7 @@ void CGarage::UpdateCrusherShake(float X, float Y)
 }
 
 // This is dumb but there is no way to avoid goto. What was there originally even?
-static bool DoINeedToRefreshPointer(CEntity * pDoor, bool bIsDummy, int8 nIndex)
+static bool DoINeedToRefreshPointer(CEntity * pDoor, bool bIsDummy, uint8 nIndex)
 {
 	bool bNeedToFindDoorEntities = false;
 	if (pDoor) {

--- a/src/core/FileLoader.cpp
+++ b/src/core/FileLoader.cpp
@@ -980,7 +980,11 @@ CFileLoader::Load2dEffect(const char *line)
 			&effect->attractor.dir.z,
 			&probability);
 		effect->attractor.type = flags;
+#ifdef FIX_BUGS
+		effect->attractor.probability = clamp(probability, 0, 255);
+#else
 		effect->attractor.probability = probability;
+#endif
 		break;
 	}
 

--- a/src/core/FileMgr.cpp
+++ b/src/core/FileMgr.cpp
@@ -142,17 +142,17 @@ static size_t
 myfread(void *buf, size_t elt, size_t n, int fd)
 {
 	if(myfiles[fd].isText){
-		char *p;
+		unsigned char *p;
 		size_t i;
 		int c;
 
 		n *= elt;
-		p = (char*)buf;
+		p = (unsigned char*)buf;
 		for(i = 0; i < n; i++){
 			c = myfgetc(fd);
 			if(c == EOF)
 				break;
-			*p++ = c;
+			*p++ = (unsigned char)c;
 		}
 		return i / elt;
 	}
@@ -163,12 +163,12 @@ static size_t
 myfwrite(void *buf, size_t elt, size_t n, int fd)
 {
 	if(myfiles[fd].isText){
-		char *p;
+		unsigned char *p;
 		size_t i;
 		int c;
 
 		n *= elt;
-		p = (char*)buf;
+		p = (unsigned char*)buf;
 		for(i = 0; i < n; i++){
 			c = *p++;
 			myfputc(c, fd);

--- a/src/core/Streaming.cpp
+++ b/src/core/Streaming.cpp
@@ -45,7 +45,11 @@ CStreamingInfo CStreaming::ms_endRequestedList;
 int32 CStreaming::ms_oldSectorX;
 int32 CStreaming::ms_oldSectorY;
 int32 CStreaming::ms_streamingBufferSize;
+#ifndef ONE_THREAD_PER_CHANNEL
 int8 *CStreaming::ms_pStreamingBuffer[2];
+#else
+int8 *CStreaming::ms_pStreamingBuffer[4];
+#endif
 size_t CStreaming::ms_memoryUsed;
 CStreamingChannel CStreaming::ms_channel[2];
 int32 CStreaming::ms_channelError;
@@ -198,6 +202,10 @@ CStreaming::Init2(void)
 	ms_pStreamingBuffer[0] = (int8*)RwMallocAlign(ms_streamingBufferSize*CDSTREAM_SECTOR_SIZE, CDSTREAM_SECTOR_SIZE);
 	ms_streamingBufferSize /= 2;
 	ms_pStreamingBuffer[1] = ms_pStreamingBuffer[0] + ms_streamingBufferSize*CDSTREAM_SECTOR_SIZE;
+#ifdef ONE_THREAD_PER_CHANNEL
+	ms_pStreamingBuffer[2] = (int8*)RwMallocAlign(ms_streamingBufferSize*2*CDSTREAM_SECTOR_SIZE, CDSTREAM_SECTOR_SIZE);
+	ms_pStreamingBuffer[3] = ms_pStreamingBuffer[2] + ms_streamingBufferSize*CDSTREAM_SECTOR_SIZE;
+#endif
 	debug("Streaming buffer size is %d sectors", ms_streamingBufferSize);
 
 	// PC only, figure out how much memory we got
@@ -1831,6 +1839,109 @@ CStreaming::LoadRequestedModels(void)
 	}
 }
 
+
+// Let's load models first, then process it. Unfortunately processing models are still single-threaded.
+// Currently only supported on POSIX streamer.
+#ifdef ONE_THREAD_PER_CHANNEL
+void
+CStreaming::LoadAllRequestedModels(bool priority)
+{
+	static bool bInsideLoadAll = false;
+	int imgOffset, streamId, status;
+	int i;
+	uint32 posn, size;
+
+	if(bInsideLoadAll)
+		return;
+
+	FlushChannels();
+	imgOffset = GetCdImageOffset(CdStreamGetLastPosn());
+
+	int streamIds[ARRAY_SIZE(ms_pStreamingBuffer)];
+	int streamSizes[ARRAY_SIZE(ms_pStreamingBuffer)];
+	int streamPoses[ARRAY_SIZE(ms_pStreamingBuffer)];
+	bool first = true;
+	int processI = 0;
+
+	while (true) {
+		// Enumerate files and start reading
+		for (int i=0; i<ARRAY_SIZE(ms_pStreamingBuffer); i++) {
+			if (!first && streamIds[i] != -1) {
+				processI = i;
+				continue;
+			}
+
+			if(ms_endRequestedList.m_prev != &ms_startRequestedList){
+				streamId = GetNextFileOnCd(0, priority);
+				if(streamId == -1){
+					streamIds[i] = -1;
+					break;
+				}
+
+				if (ms_aInfoForModel[streamId].GetCdPosnAndSize(posn, size)) {
+					streamIds[i] = -1;
+					if (size > (uint32)ms_streamingBufferSize) {
+						if (i + 1 == ARRAY_SIZE(ms_pStreamingBuffer))
+							continue;
+						else if (!first && streamIds[i+1] != -1)
+							continue;
+					} else {
+						if (i != 0 && streamIds[i-1] != -1 && streamSizes[i-1] > (uint32)ms_streamingBufferSize)
+							continue;
+					}
+					ms_aInfoForModel[streamId].RemoveFromList();
+					DecrementRef(streamId);
+
+					streamIds[i] = streamId;
+					streamSizes[i] = size;
+					streamPoses[i] = posn;
+					CdStreamRead(i, ms_pStreamingBuffer[i], imgOffset+posn, size);
+					processI = i;
+				} else {
+					ms_aInfoForModel[streamId].RemoveFromList();
+					DecrementRef(streamId);
+
+					ms_aInfoForModel[streamId].m_loadState = STREAMSTATE_LOADED;
+					streamIds[i] = -1;
+				}
+			} else
+				streamIds[i] = -1;
+		}
+
+		first = false;
+
+		// Now process
+		if (streamIds[processI] == -1) 
+			break;
+
+		// Try again on error
+		while (CdStreamSync(processI) != STREAM_NONE) {
+			CdStreamRead(processI, ms_pStreamingBuffer[processI], imgOffset+streamPoses[processI], streamSizes[processI]);
+		}
+		ms_aInfoForModel[streamIds[processI]].m_loadState = STREAMSTATE_READING;
+		
+		MakeSpaceFor(streamSizes[processI] * CDSTREAM_SECTOR_SIZE);
+		ConvertBufferToObject(ms_pStreamingBuffer[processI], streamIds[processI]);
+		if(ms_aInfoForModel[streamIds[processI]].m_loadState == STREAMSTATE_STARTED)
+			FinishLoadingLargeFile(ms_pStreamingBuffer[processI], streamIds[processI]);
+
+		if(streamIds[processI] < STREAM_OFFSET_TXD){
+			CSimpleModelInfo *mi = (CSimpleModelInfo*)CModelInfo::GetModelInfo(streamIds[processI]);
+			if(mi->IsSimple())
+				mi->m_alpha = 255;
+		}
+		streamIds[processI] = -1;
+	}
+
+	ms_bLoadingBigModel = false;
+	for(i = 0; i < 4; i++){
+		ms_channel[1].streamIds[i] = -1;
+		ms_channel[1].offsets[i] = -1;
+	}
+	ms_channel[1].state = CHANNELSTATE_IDLE;
+	bInsideLoadAll = false;
+}
+#else
 void
 CStreaming::LoadAllRequestedModels(bool priority)
 {
@@ -1883,6 +1994,7 @@ CStreaming::LoadAllRequestedModels(bool priority)
 	ms_channel[1].state = CHANNELSTATE_IDLE;
 	bInsideLoadAll = false;
 }
+#endif
 
 void
 CStreaming::FlushChannels(void)
@@ -1914,6 +2026,14 @@ CStreaming::FlushRequestList(void)
 		next = si->m_next;
 		RemoveModel(si - ms_aInfoForModel);
 	}
+#ifndef _WIN32
+	if(ms_channel[0].state == CHANNELSTATE_READING) {
+		flushStream[0] = 1;
+	}
+	if(ms_channel[1].state == CHANNELSTATE_READING) {
+		flushStream[1] = 1;
+	}
+#endif
 	FlushChannels();
 }
 

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -106,7 +106,7 @@ typedef uint16_t wchar;
 inline uint32 dpb(uint32 b, uint32 p, uint32 s, uint32 w)
 {
 	uint32 m = MASK(p,s);
-	return w & ~m | b<<p & m;
+	return (w & ~m) | ((b<<p) & m);
 }
 inline uint32 ldb(uint32 p, uint32 s, uint32 w)
 {

--- a/src/extras/frontendoption.cpp
+++ b/src/extras/frontendoption.cpp
@@ -56,7 +56,7 @@ GetNumberOfMenuOptions(int screen)
 uint8
 GetLastMenuScreen()
 {
-	uint8 page = -1;
+	int8 page = -1;
 	for (int i = 0; i < MENUPAGES; i++) {
 		if (strcmp(aScreens[i].m_ScreenName, "") == 0 && aScreens[i].unk == 0)
 			break;

--- a/src/vehicles/CarGen.cpp
+++ b/src/vehicles/CarGen.cpp
@@ -22,8 +22,13 @@ uint32 CTheCarGenerators::CurrentActiveCount;
 
 void CCarGenerator::SwitchOff()
 {
-	m_nUsesRemaining = 0;
-	--CTheCarGenerators::CurrentActiveCount;
+#ifdef FIX_BUGS
+	if (m_nUsesRemaining != 0)
+#endif
+	{
+		m_nUsesRemaining = 0;
+		--CTheCarGenerators::CurrentActiveCount;
+	}
 }
 
 void CCarGenerator::SwitchOn()

--- a/src/vehicles/Vehicle.h
+++ b/src/vehicles/Vehicle.h
@@ -111,7 +111,7 @@ public:
 	CAutoPilot AutoPilot;
 	uint8 m_currentColour1;
 	uint8 m_currentColour2;
-	uint8 m_aExtras[2];
+	int8 m_aExtras[2];
 	int16 m_nAlarmState;
 	int16 m_nMissionValue;
 	CPed *pDriver;

--- a/src/weapons/WeaponInfo.cpp
+++ b/src/weapons/WeaponInfo.cpp
@@ -160,17 +160,17 @@ CWeaponInfo::LoadWeaponData(void)
 		ms_apWeaponInfos[weaponType].m_fAnimFrameFire = delayBetweenAnimAndFire / 30.0f;
 		ms_apWeaponInfos[weaponType].m_fAnim2FrameFire = delayBetweenAnim2AndFire / 30.0f;
 		ms_apWeaponInfos[weaponType].m_nModelId = modelId;
-		ms_apWeaponInfos[weaponType].m_bUseGravity = flags;
-		ms_apWeaponInfos[weaponType].m_bSlowsDown = flags >> 1;
-		ms_apWeaponInfos[weaponType].m_bDissipates = flags >> 2;
-		ms_apWeaponInfos[weaponType].m_bRandSpeed = flags >> 3;
-		ms_apWeaponInfos[weaponType].m_bExpands = flags >> 4;
-		ms_apWeaponInfos[weaponType].m_bExplodes = flags >> 5;
-		ms_apWeaponInfos[weaponType].m_bCanAim = flags >> 6;
-		ms_apWeaponInfos[weaponType].m_bCanAimWithArm = flags >> 7;
-		ms_apWeaponInfos[weaponType].m_b1stPerson = flags >> 8;
-		ms_apWeaponInfos[weaponType].m_bHeavy = flags >> 9;
-		ms_apWeaponInfos[weaponType].m_bThrow = flags >> 10;
+		ms_apWeaponInfos[weaponType].m_bUseGravity = flags & 1;
+		ms_apWeaponInfos[weaponType].m_bSlowsDown = (flags >> 1) & 1;
+		ms_apWeaponInfos[weaponType].m_bDissipates = (flags >> 2) & 1;
+		ms_apWeaponInfos[weaponType].m_bRandSpeed = (flags >> 3) & 1;
+		ms_apWeaponInfos[weaponType].m_bExpands = (flags >> 4) & 1;
+		ms_apWeaponInfos[weaponType].m_bExplodes = (flags >> 5) & 1;
+		ms_apWeaponInfos[weaponType].m_bCanAim = (flags >> 6) & 1;
+		ms_apWeaponInfos[weaponType].m_bCanAimWithArm = (flags >> 7) & 1;
+		ms_apWeaponInfos[weaponType].m_b1stPerson = (flags >> 8) & 1;
+		ms_apWeaponInfos[weaponType].m_bHeavy = (flags >> 9) & 1;
+		ms_apWeaponInfos[weaponType].m_bThrow = (flags >> 10) & 1;
 	}
 }
 


### PR DESCRIPTION
- Now on flushing streaming will flush streaming for real by interrupting the file read
- Starting file read on a streaming channel will interrupt ongoing one as the how it was supposed to be from the beginning
- Multiple sources say fgetc and fputc accepts/outputs unsigned char (sanitizer also whines about it), therefore unsigned char casts.

If ONE_THREAD_PER_CHANNEL is defined;
- LoadAllRequestedModels will be able to read 4 files at once (not processing tho)
- Fix deadlocks introduced by Mac support
