### PR TITLE
Linux/macOS: allow storage of game data in XDG standard path

### DIFF
--- a/src/core/CdStreamPosix.cpp
+++ b/src/core/CdStreamPosix.cpp
@@ -17,6 +17,9 @@
 #include "CdStream.h"
 #include "rwcore.h"
 #include "RwHelper.h"
+#ifdef XDG_ROOT
+#include "FileMgr.h"
+#endif
 
 #define CDDEBUG(f, ...)   debug ("%s: " f "\n", "cdvd_stream", ## __VA_ARGS__)
 #define CDTRACE(f, ...)   printf("%s: " f "\n", "cdvd_stream", ## __VA_ARGS__)
@@ -139,12 +142,23 @@ CdStreamInitThread(void)
 #endif
 }
 
+static const char *gta3ImgPath = "models/gta3.img";
+
 void
 CdStreamInit(int32 numChannels)
 {
     struct statvfs fsInfo;
+    char imgPath[128] = {'\0'};
 
-    if((statvfs("models/gta3.img", &fsInfo)) < 0)
+#ifdef XDG_ROOT
+    const char *rootDir = CFileMgr::GetRootDirName();
+    strncpy(imgPath, rootDir, strlen(rootDir) - 1);
+    strcat(imgPath, "/");
+    strcat(imgPath, gta3ImgPath);
+#else
+    strcpy(imgPath, gta3ImgPath);
+#endif
+    if((statvfs(imgPath, &fsInfo)) < 0)
     {
         CDTRACE("can't get filesystem info");
         ASSERT(0);

--- a/src/core/FileMgr.h
+++ b/src/core/FileMgr.h
@@ -20,4 +20,7 @@ public:
 	static int CloseFile(int fd);
 	static int GetErrorReadWrite(int fd);
 	static char *GetRootDirName() { return ms_rootDirName; }
+#ifdef XDG_ROOT
+  static void GetHomeDirectory(char *homeDir);
+#endif
 };

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -311,3 +311,6 @@ enum Config {
 	#define PC_PARTICLE
 	#define VC_PED_PORTS // To not process collisions always. But should be tested if that's really beneficial
 #endif
+
+// Store GTA 3 files in ${HOME}/.local/share/re3
+// #define XDG_ROOT


### PR DESCRIPTION
[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

In `src/core/config.h`, enable `XDG_ROOT`.

Store the game data in `~/.local/share/re3`. This directory will be created if it does not exist. The `re3` binary no longer has to be in the same place. The `re3` binary won't care where it is located.

Of course, this is only for Linux/macOS but for macOS if I get unlazy I will make the storage point in a more normal spot on that OS. I suppose this could work on Windows under MSYS or Cygwin, or even WSL.