### PR TITLE
macOS: allow storage of game files in ~/Library/Application Support

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,30 @@
+{
+  "configurations": [
+    {
+      "name": "Mac",
+      "includePath": [
+        "${default}",
+        "src/fakerw",
+        "src/math",
+        "src/render",
+        "src/skel",
+        "vendor/librw"
+      ],
+      "defines": [],
+      "macFrameworkPath": [
+        "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+      ],
+      "compilerPath": "/opt/local/bin/clang",
+      "compilerArgs": ["-g"],
+      "cStandard": "gnu11",
+      "cppStandard": "gnu++14",
+      "browse": {
+        "path": [
+          "/opt/local/include",
+          "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
+        ]
+      }
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+  "configurations": [
+    {
+      "MIMode": "gdb",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "name": "(gdb) Launch",
+      "preLaunchTask": "Compile (Linux x64)",
+      "program": "${workspaceFolder}/bin/linux-amd64-librw_gl3_glfw-oal/Debug/re3",
+      "request": "launch",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "ignoreFailures": true,
+          "text": "-enable-pretty-printing"
+        }
+      ],
+      "stopAtEntry": false,
+      "targetArchitecture": "x64",
+      "type": "cppdbg"
+    },
+    {
+      "MIMode": "lldb",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "name": "(lldb) Launch",
+      "preLaunchTask": "Compile (macOS x64)",
+      "program": "${workspaceFolder}/bin/macosx-amd64-librw_gl3_glfw-oal/Debug/re3.app",
+      "request": "launch",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for lldb",
+          "ignoreFailures": true,
+          "text": "-enable-pretty-printing"
+        }
+      ],
+      "stopAtEntry": false,
+      "targetArchitecture": "x64",
+      "type": "cppdbg"
+    }
+  ],
+  "version": "0.2.0"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "C_Cpp.default.cStandard": "gnu11",
+    "C_Cpp.default.cppStandard": "gnu++14",
+    "C_Cpp.default.includePath": [
+        "src/fakerw",
+        "src/math",
+        "src/render",
+        "src/rw",
+        "src/skel",
+        "vendor/librw"
+    ],
+    "C_Cpp.vcFormat.indent.gotoLabels": "leftmostColumn",
+    "C_Cpp.vcFormat.space.pointerReferenceAlignment": "right",
+    "cSpell.enabled": false,
+    "editor.insertSpaces": false,
+    "editor.tabSize": 4,
+    "files.trimFinalNewlines": false,
+    "files.trimTrailingWhitespace": false,
+    "prettier.tabWidth": 4
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,65 @@
+{
+    "inputs": [
+        {
+            "default": "5",
+            "description": "Number of jobs to run simultaneously when compiling",
+            "id": "numberOfJobs",
+            "type": "promptString"
+        }
+    ],
+    "tasks": [
+        {
+            "args": ["--with-librw", "gmake2"],
+            "command": "./premake5Linux",
+            "label": "Premake (Linux)",
+            "problemMatcher": "$gcc",
+            "type": "shell"
+        },
+        {
+            "args": ["--with-librw", "gmake2"],
+            "command": "premake5",
+            "label": "Premake (macOS)",
+            "problemMatcher": "$gcc",
+            "type": "shell"
+        },
+        {
+            "args": [
+                "-j${input:numberOfJobs}",
+                "config=debug_linux-amd64-librw_gl3_glfw-oal",
+                "verbose=1"
+            ],
+            "command": "make",
+            "dependsOn": "Premake (Linux)",
+            "group": {
+                "isDefault": true,
+                "kind": "build"
+            },
+            "label": "Compile (Linux x64)",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "problemMatcher": "$gcc",
+            "type": "shell"
+        },
+        {
+            "args": [
+                "-j5",
+                "config=debug_macosx-amd64-librw_gl3_glfw-oal",
+                "verbose=1"
+            ],
+            "command": "make",
+            "dependsOn": "Premake (macOS)",
+            "group": {
+                "isDefault": true,
+                "kind": "build"
+            },
+            "label": "Compile (macOS x64)",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "problemMatcher": "$gcc",
+            "type": "shell"
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/src/core/CdStreamPosix.cpp
+++ b/src/core/CdStreamPosix.cpp
@@ -17,7 +17,7 @@
 #include "CdStream.h"
 #include "rwcore.h"
 #include "RwHelper.h"
-#ifdef XDG_ROOT
+#if defined(XDG_ROOT) || defined(APPSUPPORT_ROOT)
 #include "FileMgr.h"
 #endif
 
@@ -148,9 +148,9 @@ void
 CdStreamInit(int32 numChannels)
 {
     struct statvfs fsInfo;
-    char imgPath[128] = {'\0'};
+    char imgPath[PATH_MAX] = {'\0'};
 
-#ifdef XDG_ROOT
+#if defined(XDG_ROOT) || defined(APPSUPPORT_ROOT)
     const char *rootDir = CFileMgr::GetRootDirName();
     strncpy(imgPath, rootDir, strlen(rootDir) - 1);
     strcat(imgPath, "/");

--- a/src/core/CdStreamPosix.cpp
+++ b/src/core/CdStreamPosix.cpp
@@ -17,6 +17,9 @@
 #include "CdStream.h"
 #include "rwcore.h"
 #include "RwHelper.h"
+#ifdef XDG_ROOT
+#include "FileMgr.h"
+#endif
 
 #define CDDEBUG(f, ...)   debug ("%s: " f "\n", "cdvd_stream", ## __VA_ARGS__)
 #define CDTRACE(f, ...)   printf("%s: " f "\n", "cdvd_stream", ## __VA_ARGS__)
@@ -139,12 +142,23 @@ CdStreamInitThread(void)
 #endif
 }
 
+static const char *gta3ImgPath = "models/gta3.img";
+
 void
 CdStreamInit(int32 numChannels)
 {
     struct statvfs fsInfo;
+    char imgPath[128] = {'\0'};
 
-    if((statvfs("models/gta3.img", &fsInfo)) < 0)
+#ifdef XDG_ROOT
+    const char *rootDir = CFileMgr::GetRootDirName();
+    strncpy(imgPath, rootDir, strlen(rootDir) - 1);
+    strcat(imgPath, "/");
+    strcat(imgPath, gta3ImgPath);
+#else
+    strcpy(imgPath, gta3ImgPath);
+#endif
+    if((statvfs(imgPath, &fsInfo)) < 0)
     {
         CDTRACE("can't get filesystem info");
         ASSERT(0);

--- a/src/core/FileMgr.h
+++ b/src/core/FileMgr.h
@@ -22,5 +22,6 @@ public:
 	static char *GetRootDirName() { return ms_rootDirName; }
 #ifdef XDG_ROOT
   static void GetHomeDirectory(char *homeDir);
+  static void GetXDGDataHome(char *homeDir);
 #endif
 };

--- a/src/core/FileMgr.h
+++ b/src/core/FileMgr.h
@@ -20,8 +20,10 @@ public:
 	static int CloseFile(int fd);
 	static int GetErrorReadWrite(int fd);
 	static char *GetRootDirName() { return ms_rootDirName; }
-#ifdef XDG_ROOT
+#if defined(XDG_ROOT) || defined(APPSUPPORT_ROOT)
   static void GetHomeDirectory(char *homeDir);
+#endif
+#ifdef XDG_ROOT
   static void GetXDGDataHome(char *homeDir);
 #endif
 };

--- a/src/core/FileMgr.h
+++ b/src/core/FileMgr.h
@@ -20,4 +20,7 @@ public:
 	static int CloseFile(int fd);
 	static int GetErrorReadWrite(int fd);
 	static char *GetRootDirName() { return ms_rootDirName; }
+#ifdef XDG_ROOT
+  static void GetHomeDirectory(char *homeDir);
+#endif
 };

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -311,3 +311,6 @@ enum Config {
 	#define PC_PARTICLE
 	#define VC_PED_PORTS // To not process collisions always. But should be tested if that's really beneficial
 #endif
+
+// Store GTA 3 files in ${HOME}/.local/share/re3
+// #define XDG_ROOT

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -314,3 +314,8 @@ enum Config {
 
 // Store GTA 3 files in ${HOME}/.local/share/re3
 // #define XDG_ROOT
+
+#ifdef __APPLE__
+// Store GTA 3 files in ${HOME}/Library/Application Support/re3
+// #define APPSUPPORT_ROOT
+#endif


### PR DESCRIPTION
Same as #746 but more standard path for macOS.

This should not be merged before #746.