### PR TITLE
Use intptr/uintptr to avoid warnings

### DIFF
--- a/src/core/Zones.h
+++ b/src/core/Zones.h
@@ -106,7 +106,7 @@ public:
 	static int16 FindAudioZone(CVector *pos);
 	static eLevelName FindZoneForPoint(const CVector &pos);
 	static CZone *GetPointerForZoneIndex(int32 i) { return i == -1 ? nil : &ZoneArray[i]; }
-	static int32 GetIndexForZonePointer(CZone *zone) { return zone == nil ? -1 : zone - ZoneArray; }
+	static intptr GetIndexForZonePointer(CZone *zone) { return zone == nil ? -1 : zone - ZoneArray; }
 	static void AddZoneToAudioZoneArray(CZone *zone);
 	static void InitialiseAudioZoneArray(void);
 	static void SaveAllZones(uint8 *buffer, uint32 *length);

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -72,6 +72,7 @@ typedef uint16_t uint16;
 typedef int16_t int16;
 typedef uint32_t uint32;
 typedef int32_t int32;
+typedef intptr_t intptr;
 typedef uintptr_t uintptr;
 typedef uint64_t uint64;
 typedef int64_t int64;

--- a/src/core/templates.h
+++ b/src/core/templates.h
@@ -127,9 +127,9 @@ public:
 		int i = GetJustIndex(entry);
 		return m_flags[i].u + (i<<8);
 	}
-	int GetJustIndex(T *entry){
+	intptr GetJustIndex(T *entry){
 		// TODO: the cast is unsafe
-		return (int)((U*)entry - m_entries);
+		return (U*)entry - m_entries;
 	}
 	int GetNoOfUsedSpaces(void) const{
 		int i;

--- a/src/render/Glass.cpp
+++ b/src/render/Glass.cpp
@@ -256,7 +256,7 @@ CGlass::Render(void)
 	RwRenderStateSet(rwRENDERSTATEZWRITEENABLE,      (void *)FALSE);
 	RwRenderStateSet(rwRENDERSTATETEXTUREFILTER,     (void *)rwFILTERLINEAR);
 	RwRenderStateSet(rwRENDERSTATEFOGENABLE,         (void *)TRUE);
-	RwRenderStateSet(rwRENDERSTATEFOGCOLOR,          (void *)RWRGBALONG(CTimeCycle::GetFogRed(), CTimeCycle::GetFogGreen(), CTimeCycle::GetFogBlue(), 255));
+	RwRenderStateSet(rwRENDERSTATEFOGCOLOR,          (void *)(uintptr)RWRGBALONG(CTimeCycle::GetFogRed(), CTimeCycle::GetFogGreen(), CTimeCycle::GetFogBlue(), 255));
 	RwRenderStateSet(rwRENDERSTATESRCBLEND,          (void *)rwBLENDONE);
 	RwRenderStateSet(rwRENDERSTATEDESTBLEND,         (void *)rwBLENDONE);
 	RwRenderStateSet(rwRENDERSTATEVERTEXALPHAENABLE, (void *)TRUE);

--- a/src/render/SpecialFX.cpp
+++ b/src/render/SpecialFX.cpp
@@ -252,7 +252,7 @@ CMotionBlurStreaks::Render(void)
 				RwRenderStateSet(rwRENDERSTATEVERTEXALPHAENABLE, (void*)TRUE);
 				RwRenderStateSet(rwRENDERSTATEFOGENABLE, (void *)TRUE);
 				RwRenderStateSet(rwRENDERSTATEFOGCOLOR,
-					(void*)RWRGBALONG(CTimeCycle::GetFogRed(), CTimeCycle::GetFogGreen(), CTimeCycle::GetFogBlue(), 255));
+					(void*)(uintptr)RWRGBALONG(CTimeCycle::GetFogRed(), CTimeCycle::GetFogGreen(), CTimeCycle::GetFogBlue(), 255));
 				RwRenderStateSet(rwRENDERSTATESRCBLEND, (void*)rwBLENDSRCALPHA);
 				RwRenderStateSet(rwRENDERSTATEDESTBLEND, (void*)rwBLENDINVSRCALPHA);
 				RwRenderStateSet(rwRENDERSTATETEXTURERASTER, (void*)FALSE);

--- a/src/rw/RwHelper.cpp
+++ b/src/rw/RwHelper.cpp
@@ -115,7 +115,7 @@ DefinedState(void)
 	RwRenderStateSet(rwRENDERSTATEBORDERCOLOR, (void*)RWRGBALONG(0, 0, 0, 255));
 	RwRenderStateSet(rwRENDERSTATEFOGENABLE, (void*)FALSE);
 	RwRenderStateSet(rwRENDERSTATEFOGCOLOR,
-		(void*)RWRGBALONG(CTimeCycle::GetFogRed(), CTimeCycle::GetFogGreen(), CTimeCycle::GetFogBlue(), 255));
+		(void*)(uintptr)RWRGBALONG(CTimeCycle::GetFogRed(), CTimeCycle::GetFogGreen(), CTimeCycle::GetFogBlue(), 255));
 	RwRenderStateSet(rwRENDERSTATEFOGTYPE, (void*)rwFOGTYPELINEAR);
 	RwRenderStateSet(rwRENDERSTATECULLMODE, (void*)rwCULLMODECULLNONE);
 

--- a/src/rw/VisibilityPlugins.cpp
+++ b/src/rw/VisibilityPlugins.cpp
@@ -216,7 +216,7 @@ CVisibilityPlugins::RenderObjNormalAtomic(RpAtomic *atomic)
 }
 
 RpAtomic*
-CVisibilityPlugins::RenderAlphaAtomic(RpAtomic *atomic, int alpha)
+CVisibilityPlugins::RenderAlphaAtomic(RpAtomic *atomic, intptr alpha)
 {
 	RpGeometry *geo;
 	uint32 flags;
@@ -236,7 +236,7 @@ CVisibilityPlugins::RenderFadingAtomic(RpAtomic *atomic, float camdist)
 {
 	RpAtomic *lodatm;
 	float fadefactor;
-	uint32 alpha;
+	uintptr alpha;
 	CSimpleModelInfo *mi;
 
 	mi = GetAtomicModelInfo(atomic);

--- a/src/rw/VisibilityPlugins.h
+++ b/src/rw/VisibilityPlugins.h
@@ -45,7 +45,7 @@ public:
 
 	static RpAtomic *RenderWheelAtomicCB(RpAtomic *atomic);
 	static RpAtomic *RenderObjNormalAtomic(RpAtomic *atomic);
-	static RpAtomic *RenderAlphaAtomic(RpAtomic *atomic, int alpha);
+	static RpAtomic *RenderAlphaAtomic(RpAtomic *atomic, intptr alpha);
 	static RpAtomic *RenderFadingAtomic(RpAtomic *atm, float dist);
 
 	static RpAtomic *RenderVehicleHiDetailCB(RpAtomic *atomic);

--- a/src/vehicles/Automobile.cpp
+++ b/src/vehicles/Automobile.cpp
@@ -4558,7 +4558,7 @@ SetVehicleAtomicVisibilityCB(RwObject *object, void *data)
 }
 
 void
-CAutomobile::SetComponentVisibility(RwFrame *frame, uint32 flags)
+CAutomobile::SetComponentVisibility(RwFrame *frame, uintptr flags)
 {
 	HideAllComps();
 	bIsDamaged = true;

--- a/src/vehicles/Automobile.h
+++ b/src/vehicles/Automobile.h
@@ -172,7 +172,7 @@ public:
 	void SetDoorDamage(int32 component, eDoors door, bool noFlyingComponents = false);
 
 	void Fix(void);
-	void SetComponentVisibility(RwFrame *frame, uint32 flags);
+	void SetComponentVisibility(RwFrame *frame, uintptr flags);
 	void SetupModelNodes(void);
 	void SetTaxiLight(bool light);
 	bool GetAllWheelsOffGround(void);


### PR DESCRIPTION
Not sure if 100% good usage, but mutes annoying warnings.