### PR TITLE
Add basic support for cmake on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(re3 C CXX)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+if(WIN32)
+    set(RE3_AUDIOS "NULL" "OAL" "MSS")
+else()
+    set(RE3_AUDIOS "NULL" "OAL")
+endif()
+
+set(RE3_AUDIO "OAL" CACHE STRING "Audio")
+
+set_property(CACHE RE3_AUDIO PROPERTY STRINGS ${RE3_AUDIOS})
+message(STATUS "RE3_AUDIO = ${RE3_AUDIO} (choices=${RE3_AUDIOS})")
+set("RE3_AUDIO_${RE3_AUDIO}" ON)
+if(NOT RE3_AUDIO IN_LIST RE3_AUDIOS)
+    message(FATAL_ERROR "Illegal RE3_AUDIO=${RE3_AUDIO}")
+endif()
+
+if(RE3_INSTALL)
+    include(GNUInstallDirs)
+    set(RE3_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/re3")
+endif()
+
+add_subdirectory("vendor/librw")
+add_subdirectory(src)
+
+if(RE3_INSTALL)
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(re3-config.cmake.in re3-config.cmake
+        INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}"
+        )
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/re3-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+        )
+    install(
+        EXPORT re3-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+        )
+
+    include(CMakeCPack.cmake)
+endif()

--- a/cmake/FindMPG123.cmake
+++ b/cmake/FindMPG123.cmake
@@ -1,0 +1,28 @@
+# - Find mpg123
+# Find the native mpg123 includes and library
+#
+#  MPG123_INCLUDE_DIR - where to find mpg123.h
+#  MPG123_LIBRARIES   - List of libraries when using mpg123.
+#  MPG123_FOUND       - True if mpg123 found.
+
+IF(MPG123_INCLUDE_DIR AND MPG123_LIBRARIES)
+  # Already in cache, be silent
+  SET(MPG123_FIND_QUIETLY TRUE)
+ENDIF(MPG123_INCLUDE_DIR AND MPG123_LIBRARIES)
+
+FIND_PATH(MPG123_INCLUDE_DIR mpg123.h
+          PATHS "${MPG123_DIR}"
+          PATH_SUFFIXES include
+          )
+
+FIND_LIBRARY(MPG123_LIBRARIES NAMES mpg123 mpg123-0
+             PATHS "${MPG123_DIR}"
+             PATH_SUFFIXES lib
+             )
+
+# MARK_AS_ADVANCED(MPG123_LIBRARIES MPG123_INCLUDE_DIR)
+
+# handle the QUIETLY and REQUIRED arguments and set MPG123_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(MPG123 DEFAULT_MSG MPG123_LIBRARIES MPG123_INCLUDE_DIR)

--- a/cmake/FindSndFile.cmake
+++ b/cmake/FindSndFile.cmake
@@ -1,0 +1,67 @@
+# Found on http://hg.kvats.net
+#
+# - Try to find libsndfile
+# 
+# Once done this will define
+#
+#  SNDFILE_FOUND - system has libsndfile
+#  SNDFILE_INCLUDE_DIRS - the libsndfile include directory
+#  SNDFILE_LIBRARIES - Link these to use libsndfile
+#
+#  Copyright (C) 2006  Wengo
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if (SNDFILE_LIBRARIES AND SNDFILE_INCLUDE_DIRS)
+  # in cache already
+  set(SNDFILE_FOUND TRUE)
+else (SNDFILE_LIBRARIES AND SNDFILE_INCLUDE_DIRS)
+
+  find_path(SNDFILE_INCLUDE_DIR
+    NAMES
+      sndfile.h
+    PATHS
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+  )
+  
+  find_library(SNDFILE_LIBRARY
+    NAMES
+      sndfile
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  set(SNDFILE_INCLUDE_DIRS
+    ${SNDFILE_INCLUDE_DIR}
+  )
+  set(SNDFILE_LIBRARIES
+    ${SNDFILE_LIBRARY}
+  )
+
+  if (SNDFILE_INCLUDE_DIRS AND SNDFILE_LIBRARIES)
+    set(SNDFILE_FOUND TRUE)
+  endif (SNDFILE_INCLUDE_DIRS AND SNDFILE_LIBRARIES)
+
+  if (SNDFILE_FOUND)
+    if (NOT SndFile_FIND_QUIETLY)
+      message(STATUS "Found libsndfile: ${SNDFILE_LIBRARIES}")
+    endif (NOT SndFile_FIND_QUIETLY)
+  else (SNDFILE_FOUND)
+    if (SndFile_FIND_REQUIRED)
+      message(FATAL_ERROR "Could not find libsndfile")
+    endif (SndFile_FIND_REQUIRED)
+  endif (SNDFILE_FOUND)
+
+  # show the SNDFILE_INCLUDE_DIRS and SNDFILE_LIBRARIES variables only in the advanced view
+  mark_as_advanced(SNDFILE_INCLUDE_DIRS SNDFILE_LIBRARIES)
+
+endif (SNDFILE_LIBRARIES AND SNDFILE_INCLUDE_DIRS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,112 @@
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+if(${RE3_AUDIO} STREQUAL "OAL")
+        find_package(OpenAL REQUIRED)
+        find_package(MPG123 REQUIRED)
+        find_package(SndFile REQUIRED)
+endif()
+
+file(GLOB_RECURSE Sources "*.cpp" "*.h")
+
+MACRO(HEADER_DIRECTORIES return_list)
+    FILE(GLOB_RECURSE new_list *.cpp)
+    SET(dir_list "animation"
+            "audio"
+            "control"
+            "core"
+            "entities"
+            "extras"
+            "fakerw"
+            "math"
+            "modelinfo"
+            "objects"
+            "peds"
+            "render"
+            "rw"
+            "save"
+            "skel"
+            "text"
+            "vehicles"
+            "weapons")
+    FOREACH(file_path ${new_list})
+        GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
+        SET(dir_list ${dir_list} ${dir_path})
+    ENDFOREACH()
+    LIST(REMOVE_DUPLICATES dir_list)
+    SET(${return_list} ${dir_list})
+ENDMACRO()
+
+HEADER_DIRECTORIES(header_list)
+include_directories(${header_list})
+
+
+add_executable(re3 ${Sources})
+target_link_libraries(re3 librw)
+target_link_libraries(re3 Threads::Threads)
+
+if(${RE3_AUDIO} STREQUAL "OAL")
+        target_link_libraries(re3 ${OPENAL_LIBRARY})
+        target_link_libraries(re3 ${MPG123_LIBRARIES})
+        target_link_libraries(re3 ${SNDFILE_LIBRARIES})
+endif()
+
+target_include_directories(re3
+    INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    )
+
+target_compile_definitions(re3
+    PRIVATE
+        "$<IF:$<CONFIG:DEBUG>,DEBUG,NDEBUG>"
+    PUBLIC
+        "RW_${RE3_PLATFORM}"
+    )
+
+target_compile_definitions(re3 PRIVATE LIBRW=1 AUDIO_OAL=1)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    target_compile_options(re3
+        PRIVATE
+            "-Wall"
+        )
+    if (NOT RE3_PLATFORM_PS2)
+        target_compile_options(re3
+            PRIVATE
+                "-Wextra"
+                "-Wdouble-promotion"
+                "-Wpedantic"
+            )
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(re3
+        PUBLIC
+            /wd4996 /wd4244
+        )
+endif()
+
+set_target_properties(re3
+    PROPERTIES
+        C_STANDARD 11
+        C_EXTENSIONS OFF
+        C_STANDARD_REQUIRED ON
+        CXX_STANDARD 11
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+        PREFIX ""
+    )
+
+if(RE3_INSTALL)
+    target_include_directories(re3
+        INTERFACE
+            $<INSTALL_INTERFACE:${RE3_INSTALL_INCLUDEDIR}>
+        )
+
+    install(
+        TARGETS re3
+        EXPORT re3-targets
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        )
+endif()


### PR DESCRIPTION
Idea:
As all of our dependencies are using cmake, we can add them as submodules and  create new target with them. It should allow to easily build on any platform.