### PR TITLE
enable static runtime for all windows builds; fast floating point for x86/x64 builds; no sized dealloc for windows builds

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -145,7 +145,6 @@ workspace "re3"
 		
 	filter "platforms:*librw_gl3_glfw*"
 		defines { "RW_GL3" }
-		staticruntime "Off"
 		includedirs { path.join(_OPTIONS["glewdir"], "include") }
 		if(not _OPTIONS["with-librw"]) then
 			libdirs { path.join(Librw, "lib/%{getsys(cfg.system)}-%{getarch(cfg.architecture)}-gl3/%{cfg.buildcfg}") }
@@ -210,8 +209,8 @@ project "librw"
 		libdirs { "/opt/local/lib" }
 		libdirs { "/usr/local/lib" }
 
-	filter "platforms:*librw_gl3_glfw*"
-		staticruntime "Off"
+	filter "platforms:*gl3_glfw*"
+		staticruntime "off"
 	
 	filter "platforms:*RW33*"
 		flags { "ExcludeFromBuild" }
@@ -307,6 +306,9 @@ project "re3"
 		characterset ("MBCS")
 		targetextension ".exe"
 		staticruntime "on"
+
+	filter "platforms:win*glfw*"
+		staticruntime "off"
 		
 	filter "platforms:win*oal"
 		includedirs { "vendor/openal-soft/include" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -122,9 +122,11 @@ workspace "re3"
 	
 	filter { "platforms:*x86*" }
 		architecture "x86"
+		floatingpoint "Fast"
 		
 	filter { "platforms:*amd64*" }
 		architecture "amd64"
+		floatingpoint "Fast"
 
 	filter { "platforms:*arm*" }
 		architecture "ARM"
@@ -143,6 +145,7 @@ workspace "re3"
 		
 	filter "platforms:*librw_gl3_glfw*"
 		defines { "RW_GL3" }
+		staticruntime "Off"
 		includedirs { path.join(_OPTIONS["glewdir"], "include") }
 		if(not _OPTIONS["with-librw"]) then
 			libdirs { path.join(Librw, "lib/%{getsys(cfg.system)}-%{getarch(cfg.architecture)}-gl3/%{cfg.buildcfg}") }
@@ -184,6 +187,18 @@ project "librw"
 	files { path.join(Librw, "src/*.*") }
 	files { path.join(Librw, "src/*/*.*") }
 	
+	filter { "platforms:*x86*" }
+		architecture "x86"
+		floatingpoint "Fast"
+
+	filter { "platforms:*amd64*" }
+		architecture "amd64"
+		floatingpoint "Fast"
+
+	filter "platforms:win*"
+		staticruntime "on"
+		buildoptions { "/Zc:sizedDealloc-" }
+
 	filter "platforms:bsd*"
 		includedirs { "/usr/local/include" }
 		libdirs { "/usr/local/lib" }
@@ -194,6 +209,9 @@ project "librw"
 		includedirs {"/usr/local/include" }
 		libdirs { "/opt/local/lib" }
 		libdirs { "/usr/local/lib" }
+
+	filter "platforms:*librw_gl3_glfw*"
+		staticruntime "Off"
 	
 	filter "platforms:*RW33*"
 		flags { "ExcludeFromBuild" }
@@ -284,9 +302,11 @@ project "re3"
 	filter "platforms:win*"
 		files { addSrcFiles("src/skel/win") }
 		includedirs { "src/skel/win" }
+		buildoptions { "/Zc:sizedDealloc-" }
 		linkoptions "/SAFESEH:NO"
 		characterset ("MBCS")
 		targetextension ".exe"
+		staticruntime "on"
 		
 	filter "platforms:win*oal"
 		includedirs { "vendor/openal-soft/include" }
@@ -322,7 +342,6 @@ project "re3"
 	end
 
 	filter "platforms:*RW33*"
-		staticruntime "on"
 		includedirs { "sdk/rwsdk/include/d3d8" }
 		libdirs { "sdk/rwsdk/lib/d3d8/release" }
 		links { "rwcore", "rpworld", "rpmatfx", "rpskin", "rphanim", "rtbmp", "rtquat", "rtcharse" }

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -227,8 +227,10 @@ enum Config {
 #define NO_ISLAND_LOADING  // disable loadscreen between islands via loading all island data at once, consumes more memory and CPU
 //#define USE_TEXTURE_POOL
 #define CUTSCENE_BORDERS_SWITCH
+#ifdef LIBRW
 //#define EXTENDED_COLOURFILTER		// more options for colour filter (replaces mblur)
 //#define EXTENDED_PIPELINES		// custom render pipelines (includes Neo)
+#endif
 #define MULTISAMPLING		// adds MSAA option
 
 #ifdef LIBRW


### PR DESCRIPTION
Some simple premake.lua changes.

as per discussion in discord:

GTA3 was compiled with fast floating point arithmetic, aap says this caused issues on Vita (ARM), so I only set that as default for x86/amd64.

I also added the no sized dealloc option for windows, because newer MSVC toolsets add `operator delete(ptr, sizeof(class));` instead of just `operator delete(ptr)`. This is a newer c++ feature that didn't exist during gta3 times yet.

And finally, I enabled staticruntime for all windows builds, because that's the way to go with windows builds ... (and should also give a minimal performance increase).

Edit2: It turns out the glfw build fails due to the staticruntime on. I've disabled it for glfw builds.

Edit: I also added a headerguard for the extended colourfilter and pipeline defines, so that they only get used if LIBRW is defined.