### PR TITLE
red warning texts in delete save menu

### DIFF
--- a/src/core/Frontend.cpp
+++ b/src/core/Frontend.cpp
@@ -1049,6 +1049,18 @@ CMenuManager::Draw()
 	if (aScreens[m_nCurrScreen].m_ScreenName[0] != '\0') {
 		
 		PREPARE_MENU_HEADER
+#ifdef RED_DELETE_TEXTS
+		switch(m_nCurrScreen){
+		case MENUPAGE_CHOOSE_DELETE_SLOT:
+		case MENUPAGE_DELETE_SLOT_CONFIRM:
+		case MENUPAGE_DELETING_IN_PROGRESS:
+		case MENUPAGE_DELETE_FAILED:
+		case MENUPAGE_DELETING:
+		case MENUPAGE_DELETE_SUCCESS:
+			CFont::SetColor(CRGBA(220, 0, 0, 255));
+			break;
+		}
+#endif
 		CFont::PrintString(PAGE_NAME_X(MENUHEADER_POS_X), SCREEN_SCALE_FROM_BOTTOM(MENUHEADER_POS_Y), TheText.Get(aScreens[m_nCurrScreen].m_ScreenName));
 
 		// Weird place to put that.
@@ -1087,6 +1099,9 @@ CMenuManager::Draw()
 			break;
 		}
 
+#ifdef RED_DELETE_TEXTS
+		if (m_nCurrScreen == MENUPAGE_DELETE_SLOT_CONFIRM) CFont::SetColor(CRGBA(255, 0, 0, 255));
+#endif
 #ifdef FIX_BUGS
 		// Label is wrapped from right by StretchX(40)px, but wrapped from left by 40px. And this is only place R* didn't use StretchX in here.
 		CFont::PrintString(MENU_X_LEFT_ALIGNED(MENU_X_MARGIN), MENU_Y(MENUACTION_POS_Y), str);

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -283,6 +283,7 @@ enum Config {
 //#	define CIRCLE_BACK_BUTTON
 //#	define PS2_LIKE_MENU	// An effort to recreate PS2 menu, cycling through tabs, different bg etc.
 //#	define PS2_SAVE_DIALOG		// PS2 style save dialog with transparent black box
+#	define RED_DELETE_TEXTS // some red warning texts when deleting a save, i.e. "delete game" and "proceed with deleting?" to make you switch out of muscle memory mode
 #	define CUSTOM_FRONTEND_OPTIONS
 
 #	ifdef CUSTOM_FRONTEND_OPTIONS


### PR DESCRIPTION
I just deleted my main save on accident, because I accidentally entered this menu and went into muscle memory mode. These red warning texts should throw you off enough to NOT delete your save while you think you're loading it.

The red doesn't look perfect, but then of course it doesn't need to, it just needs to get your attention :)

![re3 2020-11-24 00-24-48-68](https://user-images.githubusercontent.com/765123/100027009-2a4aa980-2dec-11eb-8810-e2d9851c91f7.png)
