### PR TITLE
Update Camera.cpp - Vehicle spawning on ultrawide aspect ratios

### DIFF
--- a/src/core/Camera.cpp
+++ b/src/core/Camera.cpp
@@ -720,7 +720,7 @@ CCamera::Process(void)
 	else
 		LODDistMultiplier = 1.0f;
 	// missing on PS2
-	GenerationDistMultiplier = LODDistMultiplier;
+	GenerationDistMultiplier = 70.0f/CDraw::GetFOV() * fmin(CDraw::GetAspectRatio(),1.82f)/(4.0f/3.0f);
 	LODDistMultiplier *= CRenderer::ms_lodDistScale;
 	//
 


### PR DESCRIPTION
#839 
camdist multiplier is consitently between 1 and 1.4 on 16:9 aspect ratio
On ultrawide, the cam dist multiplier jumps to anywhere between 2 and 3
The preferred distance generator for car objects is the cam dist multiplier * 120. Which puts cars that it's trying to generate outside of the allowed gen/draw distance for new car objects when on ultrawide. This means no new cars can spawn.
This change caps the scaling for the generation distance a bit above what it would be for 16:9 and does not affect the LOD multiplier.