### PR TITLE
Another fix proposal for ultrawide

### DIFF
--- a/src/core/Camera.cpp
+++ b/src/core/Camera.cpp
@@ -720,7 +720,10 @@ CCamera::Process(void)
 #ifdef FIX_BUGS
         // from VC. to high values bug out spawns
         LODDistMultiplier = Min(LODDistMultiplier, 2.2f);
-        GenerationDistMultiplier = Min(LODDistMultiplier, 1.36f);
+        #if GTA_VERSION > GTA3_PS2_160
+        // The LODDistMultiplier bugfix can apply to PS2, but the GenerationDistMultiplier isn't used in that build
+                GenerationDistMultiplier = Min(LODDistMultiplier, 1.36f);
+        #endif
 #elif GTA_VERSION > GTA3_PS2_160
         GenerationDistMultiplier = LODDistMultiplier;
         LODDistMultiplier *= CRenderer::ms_lodDistScale;

--- a/src/core/Camera.cpp
+++ b/src/core/Camera.cpp
@@ -718,12 +718,12 @@ CCamera::Process(void)
 	else
 		LODDistMultiplier = 1.0f;
 #ifdef FIX_BUGS
-	// from VC. to high values bug out spawns
-	LODDistMultiplier = Min(LODDistMultiplier, 2.2f);
-#endif
-#if GTA_VERSION > GTA3_PS2_160
-	GenerationDistMultiplier = LODDistMultiplier;
-	LODDistMultiplier *= CRenderer::ms_lodDistScale;
+        // from VC. to high values bug out spawns
+        LODDistMultiplier = Min(LODDistMultiplier, 2.2f);
+        GenerationDistMultiplier = Min(LODDistMultiplier, 1.36f);
+#elif GTA_VERSION > GTA3_PS2_160
+        GenerationDistMultiplier = LODDistMultiplier;
+        LODDistMultiplier *= CRenderer::ms_lodDistScale;
 #endif
 
 	// Keep track of speed


### PR DESCRIPTION
@aap pushed a fix this morning, but it still seems to have the same trouble with cars not spawning.
It seems that this was happening for a couple of reasons:
1. This fix sets the LOD Distance to 2.2 and adds bug fix / ps2 version wraps, but it seems that the values are overwriting eachother depending on the config (ie, if you are both above the PS2 release & with fix_bugs)
2. The GenerationDistMultiplier really shouldn't be > ~ 1.36, and the code here appears to cap it at 2.2 per the loddist multiplier. I'm not wholly convinced these values need to be tied together in this context past that val.

So with both of these things in minds, I've modified the wraps to have an if/elif that should be kosher to the original code, and I've set a cap for the gendist var to 1.36 under fix_bugs, while still allowing the higher 2.2f max loddist mltplr from vice city.