### PR TITLE
audio: define openal extensions in re3 owned namespace

### DIFF
--- a/src/audio/oal/oal_utils.cpp
+++ b/src/audio/oal/oal_utils.cpp
@@ -3,6 +3,14 @@
 
 #ifdef AUDIO_OAL
 
+/*
+ * When linking to a static openal-soft library,
+ * the extension function inside the openal library conflict with the variables here.
+ * Therefore declare these re3 owned symbols in a private namespace.
+ */
+
+namespace re3_openal {
+
 LPALGENEFFECTS alGenEffects;
 LPALDELETEEFFECTS alDeleteEffects;
 LPALISEFFECT alIsEffect;
@@ -37,6 +45,9 @@ LPALGETFILTERIV alGetFilteriv;
 LPALGETFILTERF alGetFilterf;
 LPALGETFILTERFV alGetFilterfv;
 
+}
+
+using namespace re3_openal;
 
 void EFXInit()
 {

--- a/src/audio/oal/oal_utils.h
+++ b/src/audio/oal/oal_utils.h
@@ -11,6 +11,8 @@ void EFX_Set(ALuint effect, const EAXLISTENERPROPERTIES *props);
 void EAX3_SetReverbMix(ALuint filter, float mix);
 void SetEffectsLevel(ALuint uiFilter, float level);
 
+namespace re3_openal {
+
 extern LPALGENEFFECTS alGenEffects;
 extern LPALDELETEEFFECTS alDeleteEffects;
 extern LPALISEFFECT alIsEffect;
@@ -44,4 +46,9 @@ extern LPALGETFILTERI alGetFilteri;
 extern LPALGETFILTERIV alGetFilteriv;
 extern LPALGETFILTERF alGetFilterf;
 extern LPALGETFILTERFV alGetFilterfv;
+
+}
+
+using namespace re3_openal;
+
 #endif


### PR DESCRIPTION
Linking to a static openal-soft library causes linking conflicts.

Fixes #826