### PR TITLE
audio: only use #pragma comment(lib, xxx.lib) on MSVC

### DIFF
--- a/src/audio/oal/stream.cpp
+++ b/src/audio/oal/stream.cpp
@@ -4,7 +4,7 @@
 #include "stream.h"
 #include "sampman.h"
 
-#ifdef _WIN32
+#if defined _MSC_VER && !defined RE3_NO_AUTOLINK
 #ifdef AUDIO_OAL_USE_SNDFILE
 #pragma comment( lib, "libsndfile-1.lib" )
 #endif


### PR DESCRIPTION
`#pragma comment(lib "libmpg123-0.lib")` is only available on the MS C compiler.

This commit is extracted from #922 to avoid future merge conflicts.