### PR TITLE
Add toggle for (un)named semaphores and prevent linux header inclusion on non-linux paltforms

### DIFF
--- a/src/core/CdStreamPosix.cpp
+++ b/src/core/CdStreamPosix.cpp
@@ -1,8 +1,8 @@
 #ifndef _WIN32
 #include "common.h"
 #include "crossplatform.h"
-#include <pthread.h>
 #include <signal.h>
+#include <pthread.h>
 #include <semaphore.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -13,7 +13,10 @@
 #include <fcntl.h>
 #include <sys/resource.h>
 #include <stdarg.h>
+
+#ifdef __linux__
 #include <sys/syscall.h>
+#endif
 
 #include "CdStream.h"
 #include "rwcore.h"

--- a/src/core/CdStreamPosix.cpp
+++ b/src/core/CdStreamPosix.cpp
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/resource.h>
+#include <stdarg.h>
 #include <sys/syscall.h>
 
 #include "CdStream.h"
@@ -23,6 +24,58 @@
 
 #ifdef FLUSHABLE_STREAMING
 bool flushStream[MAX_CDCHANNELS];
+#endif
+
+#ifdef USE_UNNAMED_SEM
+
+#define RE3_SEM_OPEN(name, ...) re3_sem_open()
+sem_t*
+re3_sem_open(void)
+{
+	sem_t* sem = (sem_t*)malloc(sizeof(sem_t));
+	if (sem_init(sem, 0, 1) == -1) {
+		sem = SEM_FAILED;
+	}
+
+	return sem;
+}
+
+#define RE3_SEM_CLOSE(sem, format, ...) re3_sem_close(sem)
+void
+re3_sem_close(sem_t* sem)
+{
+	sem_destroy(sem);
+	free(sem);
+}
+
+#else
+
+#define RE3_SEM_OPEN re3_sem_open
+sem_t*
+re3_sem_open(const char* format, ...)
+{
+	char semName[20];
+	va_list va;
+	va_start(va, format);
+	vsprintf(semName, format, va);
+
+	return sem_open(semName, O_CREAT, 0644, 1);
+}
+
+#define RE3_SEM_CLOSE re3_sem_close
+void
+re3_sem_close(sem_t* sem, const char* format, ...)
+{
+	sem_close(sem);
+
+	char semName[20];
+	va_list va;
+	va_start(va, format);
+	vsprintf(semName, format, va);
+
+	sem_unlink(semName);
+}
+
 #endif
 
 struct CdReadInfo
@@ -69,14 +122,13 @@ void
 CdStreamInitThread(void)
 {
 	int status;
-	char semName[20];
 #ifndef ONE_THREAD_PER_CHANNEL
 	gChannelRequestQ.items = (int32 *)calloc(gNumChannels + 1, sizeof(int32));
 	gChannelRequestQ.head = 0;
 	gChannelRequestQ.tail = 0;
 	gChannelRequestQ.size = gNumChannels + 1;
 	ASSERT(gChannelRequestQ.items != nil );
-	gCdStreamSema = sem_open("/semaphore_cd_stream", O_CREAT, 0644, 0);
+	gCdStreamSema = RE3_SEM_OPEN("/semaphore_cd_stream");
 
 
 	if (gCdStreamSema == SEM_FAILED) {
@@ -90,8 +142,7 @@ CdStreamInitThread(void)
 	{
 		for ( int32 i = 0; i < gNumChannels; i++ )
 		{
-			sprintf(semName,"/semaphore_done%d",i);
-			gpReadInfo[i].pDoneSemaphore = sem_open(semName, O_CREAT, 0644, 0);
+			gpReadInfo[i].pDoneSemaphore = RE3_SEM_OPEN("/semaphore_done%d", i);
 
 			if (gpReadInfo[i].pDoneSemaphore == SEM_FAILED)
 			{
@@ -101,8 +152,7 @@ CdStreamInitThread(void)
 			}
 
 #ifdef ONE_THREAD_PER_CHANNEL
-			sprintf(semName,"/semaphore_start%d",i);
-			gpReadInfo[i].pStartSemaphore = sem_open(semName, O_CREAT, 0644, 0);
+			gpReadInfo[i].pStartSemaphore = RE3_SEM_OPEN("/semaphore_start%d", i);
 
 			if (gpReadInfo[i].pStartSemaphore == SEM_FAILED)
 			{
@@ -464,21 +514,14 @@ void *CdStreamThread(void *param)
 #ifndef ONE_THREAD_PER_CHANNEL
 	for ( int32 i = 0; i < gNumChannels; i++ )
 	{
-		sem_close(gpReadInfo[i].pDoneSemaphore);
-		sprintf(semName,"/semaphore_done%d",i);
-		sem_unlink(semName);
+		RE3_SEM_CLOSE(gpReadInfo[i].pDoneSemaphore, "/semaphore_done%d", i);
 	}
-	sem_close(gCdStreamSema);
-	sem_unlink("/semaphore_cd_stream");
+	RE3_SEM_CLOSE(gCdStreamSema, "/semaphore_cd_stream");
 	free(gChannelRequestQ.items);
 #else
-	sem_close(gpReadInfo[channel].pStartSemaphore);
-	sprintf(semName,"/semaphore_start%d",channel);
-	sem_unlink(semName);
+	RE3_SEM_CLOSE(gpReadInfo[channel].pStartSemaphore, "/semaphore_start%d", channel);
 
-	sem_close(gpReadInfo[channel].pDoneSemaphore);
-	sprintf(semName,"/semaphore_done%d",channel);
-	sem_unlink(semName);
+	RE3_SEM_CLOSE(gpReadInfo[channel].pDoneSemaphore, "/semaphore_done%d", channel);
 #endif
 	if (gpReadInfo)
 		free(gpReadInfo);


### PR DESCRIPTION
This adds a compile-time define that decides whether unnamed or named semaphores are used, since some platforms may not support one or the other.

Also prevents a Linux header from being included if we're not building for Linux.

This originally was a PR for the Nintendo Switch port but it's going to take a while, so let's just merge the 2 commits that are ready for now.

Original PR contents (for archival purposes):

----

This PR will bring Nintendo Switch fork loosely based on the old fork I did a couple months ago.

- [ ] CMake files to use devkitPro's Switch toolchain
- [x] Fix OpenAL variable clash when linking (#837)
- [x] Toggle (un)named semaphore usage on CdStreamPosix through ~~macro~~ function (named semaphore returns ENOSYS which means not implemented on the Switch)
- [ ] Check that the CdStreamPosix.cpp threads exit gracefully because you can't kill threads on the switch.
- [ ] Check wav support implementation (since it's using cmake, libsndfile should be easier to compile now and might be used instead of dr_wav on the old fork)
- [ ] Check audio extensions code (some EAX stuff triggers a crash on the openal switch port)
- [ ] Check `DIGITALRATE` macro for the Switch (on the old fork any value other than 48000 seems to crash)
- [ ] Check/swap X and circle/A and B controller mappings (since A on the switch is where Circle would be, but A is used for confirming rather than cancelling/going back)
- [ ] Check some custom config defines for the switch
- [ ] Check `realpath` which is apparently missing from the Switch's toolchain (?)
- [ ] Check casepath and path related functions to support switch mounted devices (paths that start with "[something]:/" like "sd:/switch/re3/models/GTA3.IMG")
- [ ] Ignore useless glfw input devices (touchscreen input implemented as "mouse" on glfw, some controller buttons getting passed as "keyboard" at the same time, etc.)
- [ ] Check screen resolution stuff (always has to be either 720p when docked, 1080p when docked)
- [x] ~~Switch stuff on main~~ glfw seems to handle this for us so no need to do that like on the old fork

Optional but nice-to-haves:
- [ ] Switch button prompts (nxbtns.txd on old fork's release)
- [ ] CPU Boost on loading screens (The switch has a feature which throttles the GPU but boosts the CPU clock up to 1,7GHz, meant for faster loading, actually saves around 3-4 seconds) examples: [1-1](https://github.com/AGraber/re3-nx/blob/e3a17f7fe35a6170eb561a58dc05631d27eb4af0/src/skel/glfw/glfw.cpp#L1556) [1-2](https://github.com/AGraber/re3-nx/blob/e3a17f7fe35a6170eb561a58dc05631d27eb4af0/src/skel/glfw/glfw.cpp#L1888) [2-1](https://github.com/AGraber/re3-nx/blob/e3a17f7fe35a6170eb561a58dc05631d27eb4af0/src/core/Game.cpp#L401) [2-2](https://github.com/AGraber/re3-nx/blob/e3a17f7fe35a6170eb561a58dc05631d27eb4af0/src/core/Game.cpp#L665)
- [ ] GPU throttle on pause menu (same as before but without the CPU boost, good for power saving)
