### PR TITLE
PostFX fixes

### DIFF
--- a/src/extras/postfx.cpp
+++ b/src/extras/postfx.cpp
@@ -48,6 +48,9 @@ CPostFX::InitOnce(void)
 void
 CPostFX::Open(RwCamera *cam)
 {
+	if(bJustInitialised){
+		CPostFX::Close();
+	}
 	uint32 width  = Pow(2.0f, int32(log2(RwRasterGetWidth (RwCameraGetRaster(cam))))+1);
 	uint32 height = Pow(2.0f, int32(log2(RwRasterGetHeight(RwCameraGetRaster(cam))))+1);
 	uint32 depth  = RwRasterGetDepth(RwCameraGetRaster(cam));

--- a/src/rw/RwHelper.cpp
+++ b/src/rw/RwHelper.cpp
@@ -6,6 +6,9 @@
 #include "Timecycle.h"
 #include "skeleton.h"
 #include "Debug.h"
+#if defined(FIX_BUGS) || defined(LIBRW)
+#include "MBlur.h"
+#endif
 #if !defined(FINAL) || defined(DEBUGMENU)
 #include "rtcharse.h"
 #endif
@@ -485,6 +488,11 @@ CameraSize(RwCamera * camera, RwRect * rect,
 
 				RwCameraSetRaster(camera, raster);
 				RwCameraSetZRaster(camera, zRaster);
+			}
+
+			if(CMBlur::BlurOn)
+			{
+				CMBlur::MotionBlurOpen(camera);
 			}
 #else
 			raster = RwCameraGetRaster(camera);


### PR DESCRIPTION
This fixes a CPostFX leak by closing it before re-opening again (happens when going out of pause menu with some settings enabled), and fixes wrong MBlur/CPostFX raster sizes by reopening them when the game's resolution changes. CPostFX is all custom and resize fix is behind `LIBRW` and `FIX_BUGS` checks.