### PR TITLE
re3: Update Linux 64bit build download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We cannot build for PS2 or Xbox yet. If you're interested in doing so, get in to
   - [Windows D3D9 MSS 32bit](https://nightly.link/GTAmodding/re3/workflows/re3_msvc_x86/master/re3_Release_win-x86-librw_d3d9-mss.zip)
   - [Windows D3D9 64bit](https://nightly.link/GTAmodding/re3/workflows/re3_msvc_amd64/master/re3_Release_win-amd64-librw_d3d9-oal.zip)
   - [Windows OpenGL 64bit](https://nightly.link/GTAmodding/re3/workflows/re3_msvc_amd64/master/re3_Release_win-amd64-librw_gl3_glfw-oal.zip)
-  - [Linux 64bit](https://nightly.link/GTAmodding/re3/workflows/build-cmake-conan/master/ubuntu-latest-gl3.zip)
+  - [Linux 64bit](https://nightly.link/GTAmodding/re3/workflows/build-cmake-conan/master/ubuntu-18.04-gl3.zip)
   - [MacOS 64bit](https://nightly.link/GTAmodding/re3/workflows/build-cmake-conan/master/macos-latest-gl3.zip)
 - Extract the downloaded zip over your GTA 3 directory and run re3. The zip includes the gamefiles and in case of OpenAL the required dlls.
 


### PR DESCRIPTION
After the commit that fixed the cmake compilation [a83ecc1](https://github.com/GTAmodding/re3/commit/a83ecc123dea8090eb158825eafb262c14bfb46e) the name of the operating system, changed by breaking the readme download link.

Here I have changed the download link to the correct name.