### PR TITLE
miami: Update Linux 64bit build download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We cannot build for PS2 or Xbox yet. If you're interested in doing so, get in to
   - [Windows D3D9 MSS 32bit](https://nightly.link/GTAmodding/re3/workflows/reVC_msvc_x86/miami/reVC_Release_win-x86-librw_d3d9-mss.zip)
   - [Windows D3D9 64bit](https://nightly.link/GTAmodding/re3/workflows/reVC_msvc_amd64/miami/reVC_Release_win-amd64-librw_d3d9-oal.zip)
   - [Windows OpenGL 64bit](https://nightly.link/GTAmodding/re3/workflows/reVC_msvc_amd64/miami/reVC_Release_win-amd64-librw_gl3_glfw-oal.zip)
-  - [Linux 64bit](https://nightly.link/GTAmodding/re3/workflows/build-cmake-conan/miami/ubuntu-latest-gl3.zip)
+  - [Linux 64bit](https://nightly.link/GTAmodding/re3/workflows/build-cmake-conan/miami/ubuntu-18.04-gl3.zip)
   - [MacOS 64bit](https://nightly.link/GTAmodding/re3/workflows/build-cmake-conan/miami/macos-latest-gl3.zip)
 - Extract the downloaded zip over your GTA VC directory and run reVC. The zip includes the gamefiles and in case of OpenAL the required dlls.
 


### PR DESCRIPTION
After the commit that fixed the cmake compilation [5341840](https://github.com/GTAmodding/re3/commit/53418409435ef601567dd3bb7831a5b34be98c59) the name of the operating system, changed by breaking the readme download link.

Here I have changed the download link to the correct name.