### PR TITLE
Fix move direction while shooting and moving

### DIFF
--- a/src/peds/PlayerPed.cpp
+++ b/src/peds/PlayerPed.cpp
@@ -510,6 +510,25 @@ CPlayerPed::DoWeaponSmoothSpray(void)
 	return false;
 }
 
+float
+CPlayerPed::GetWeaponSmoothSprayRate(void)
+{
+	if(m_nPedState == PED_ATTACK && !m_pPointGunAt) {
+		CWeaponInfo *weaponInfo = CWeaponInfo::GetWeaponInfo(GetWeapon()->m_eWeaponType);
+		switch(GetWeapon()->m_eWeaponType) {
+		case WEAPONTYPE_SHOTGUN:
+		case WEAPONTYPE_AK47:
+		case WEAPONTYPE_M16: return PI / 180.f;
+		case WEAPONTYPE_FLAMETHROWER: return PI / 80.f;
+		case WEAPONTYPE_BASEBALLBAT:
+		case WEAPONTYPE_HELICANNON: return PI / 176.f;
+		default: return -1.0f;
+		}
+	}
+	if(bIsDucking) return PI / 112.f;
+	return -1.0f;
+}
+
 void
 CPlayerPed::DoStuffToGoOnFire(void)
 {
@@ -1169,37 +1188,33 @@ CPlayerPed::ProcessPlayerWeapon(CPad *padUsed)
 void
 CPlayerPed::PlayerControlZelda(CPad *padUsed)
 {
-	bool doSmoothSpray = DoWeaponSmoothSpray();
+	float smoothSprayRate = GetWeaponSmoothSprayRate();
 	float camOrientation = TheCamera.Orientation;
 	float leftRight = padUsed->GetPedWalkLeftRight();
 	float upDown = padUsed->GetPedWalkUpDown();
 	float padMoveInGameUnit;
 	bool smoothSprayWithoutMove = false;
 
-	if (doSmoothSpray && upDown > 0.0f) {
+	if(m_pPointGunAt && !CWeaponInfo::GetWeaponInfo(GetWeapon()->m_eWeaponType)->IsFlagSet(WEAPONFLAG_CANAIM_WITHARM)) {
+		upDown = 0.0f;
+		leftRight = 0.0f;
+	}
+
+	if(smoothSprayRate > 0.0f && upDown > 0.0f) {
 		padMoveInGameUnit = 0.0f;
 		smoothSprayWithoutMove = true;
 	} else {
 		padMoveInGameUnit = CVector2D(leftRight, upDown).Magnitude() / PAD_MOVE_TO_GAME_WORLD_MOVE;
 	}
 
-	if (padMoveInGameUnit > 0.0f || smoothSprayWithoutMove) {
+	if(padMoveInGameUnit > 0.0f || smoothSprayWithoutMove) {
 		float padHeading = CGeneral::GetRadianAngleBetweenPoints(0.0f, 0.0f, -leftRight, upDown);
 		float neededTurn = CGeneral::LimitRadianAngle(padHeading - camOrientation);
-		if (doSmoothSpray) {
-			if (GetWeapon()->m_eWeaponType == WEAPONTYPE_FLAMETHROWER || GetWeapon()->m_eWeaponType == WEAPONTYPE_COLT45
-				|| GetWeapon()->m_eWeaponType == WEAPONTYPE_UZI)
-				m_fRotationDest = m_fRotationCur - leftRight / 128.0f * (PI / 80.0f) * CTimer::GetTimeStep();
-			else
-				m_fRotationDest = m_fRotationCur - leftRight / 128.0f * (PI / 128.0f) * CTimer::GetTimeStep();
+		if(smoothSprayRate > 0.0f) {
+			m_fRotationDest = m_fRotationCur - leftRight / 128.0f * smoothSprayRate * CTimer::GetTimeStep();
 		} else {
 			m_fRotationDest = neededTurn;
 		}
-
-		float maxAcc = 0.07f * CTimer::GetTimeStep();
-		m_fMoveSpeed = Min(padMoveInGameUnit, m_fMoveSpeed + maxAcc);
-
-	} else {
 		m_fMoveSpeed = 0.0f;
 	}
 

--- a/src/peds/PlayerPed.h
+++ b/src/peds/PlayerPed.h
@@ -54,6 +54,7 @@ public:
 	void SetRealMoveAnim(void);
 	void RestoreSprintEnergy(float);
 	bool DoWeaponSmoothSpray(void);
+	float GetWeaponSmoothSprayRate(void);
 	void DoStuffToGoOnFire(void);
 	bool DoesTargetHaveToBeBroken(CVector, CWeapon*);
 	void RunningLand(CPad*);


### PR DESCRIPTION
Move direction was broken when shooting and moving with Colt45 and UZI (only in Free Camera mod), fixed it. The code is taken from VC.

As long as it's not linux/cross-platform skeleton/compatibility layer, all of the code on the repo that's not behind a preprocessor condition(like FIX_BUGS) are **completely** reversed code from original binaries.  

We **don't** accept custom codes, as long as it's not wrapped via preprocessor conditions, or it's linux/cross-platform skeleton/compatibility layer.

We accept only these kinds of PRs;

- A new feature that exists in at least one of the GTAs (if it wasn't in III/VC then it doesn't have to be decompilation)  
- Game, UI or UX bug fixes (if it's a fix to R* code, it should be behind FIX_BUGS)
- Platform-specific and/or unused code that's not been reversed yet
- Makes reversed code more understandable/accurate, as in "which code would produce this assembly".
- A new cross-platform skeleton/compatibility layer, or improvements to them
- Translation fixes, for languages R* supported/outsourced
- Code that increase maintainability
