### PR TITLE
fix: add missing limits.h includes to enable bulding on musl.

### DIFF
--- a/src/core/CdStreamPosix.cpp
+++ b/src/core/CdStreamPosix.cpp
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include <sys/resource.h>
 #include <stdarg.h>
+#include <limits.h>
 
 #ifdef __linux__
 #include <sys/syscall.h>

--- a/src/skel/crossplatform.h
+++ b/src/skel/crossplatform.h
@@ -1,4 +1,5 @@
 #include <time.h>
+#include <limits.h>
 
 // This is the common include for platform/renderer specific skeletons(glfw.cpp, win.cpp etc.) and using cross platform things (like Windows directories wrapper, platform specific global arrays etc.) 
 // Functions that's different on glfw and win but have same signature, should be located on platform.h.


### PR DESCRIPTION
`src/core/CdStreamPosix.cpp` and `src/skel/crossplatform.h` require `limits.h` to be included for the build to succeed on hosts using musl as their libc implementation, otherwise they will be prompted with this error:
```sh
In file included from ../src/core/CdStreamPosix.cpp:3:
../src/skel/crossplatform.h:97:22: error: 'PATH_MAX' was not declared in this scope; did you mean 'AR_MAX'?
   97 |     #define MAX_PATH PATH_MAX
      |                      ^~~~~~~~
../src/skel/crossplatform.h:146:17: note: in expansion of macro 'MAX_PATH'
  146 |     char folder[MAX_PATH];      // for searching
      |                 ^~~~~~~~
../src/core/CdStreamPosix.cpp: In function 'uint32 GetGTA3ImgSize()':
../src/core/CdStreamPosix.cpp:246:19: error: 'PATH_MAX' was not declared in this scope; did you mean 'AR_MAX'?
  246 |         char path[PATH_MAX];
      |                   ^~~~~~~~
      |                   AR_MAX
../src/core/CdStreamPosix.cpp:247:32: error: 'path' was not declared in this scope
  247 |         realpath(gImgNames[0], path);
      |                                ^~~~
```

i have successfully built and tested this on my x86_64 musl 1.2.1 host for both `re3` and `reVC`.