### PR TITLE
fix: printHash.sh; replace echo -n, check if $1 is set.

### DIFF
--- a/printHash.sh
+++ b/printHash.sh
@@ -1,12 +1,14 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+if [ -z "${1}" ]
+ then
+  printf "%s\n" "Input the path to the file for writing the commit hash to."
+ else
+  printf "%s" "#define GIT_SHA1 \"" > $1
 
-> $1
+  if (command -v "git" >/dev/null) then
+   git rev-parse --short HEAD | tr -d '\n' >> $1
+  fi
 
-echo -n "#define GIT_SHA1 \"" > $1
-
-if (command -v "git" >/dev/null) then
-git rev-parse --short HEAD | tr -d '\n' >> $1
+  printf "%s\n" "\"" >> $1
+  printf "%s\n" "const char* g_GIT_SHA1 = GIT_SHA1;" >> $1
 fi
-
-echo "\"" >> $1
-echo "const char* g_GIT_SHA1 = GIT_SHA1;" >> $1


### PR DESCRIPTION
this pull request rewrites `printHash.sh` to get rid of the dependency on bash and bashisms (the use of `echo -n`) for hosts without bash. it also does a simple check to see if `$1` is set and removes the unnecessary `>$1` as the first invocation of `printf` already does that.

checked with `bash 5.1.8`, `yash 2.51` and `busybox ash 1.33.1`.