### PR TITLE
Fix move direction with certain weapons

### DIFF
--- a/src/peds/Ped.cpp
+++ b/src/peds/Ped.cpp
@@ -1321,9 +1321,11 @@ CPed::CalculateNewVelocity(void)
 			limitedRotDest -= 2 * PI;
 		}
 
+#ifdef THIS_IS_STUPID
 		if (IsPlayer() && m_nPedState == PED_ATTACK)
 			headAmount /= 4.0f;
-
+#endif
+		
 		float neededTurn = limitedRotDest - m_fRotationCur;
 		if (neededTurn <= headAmount) {
 			if (neededTurn > (-headAmount))

--- a/src/peds/PlayerPed.h
+++ b/src/peds/PlayerPed.h
@@ -53,7 +53,12 @@ public:
 	class CPlayerInfo *GetPlayerInfoForThisPlayerPed();
 	void SetRealMoveAnim(void);
 	void RestoreSprintEnergy(float);
-	bool DoWeaponSmoothSpray(void);
+#ifdef FIX_BUGS
+	float
+#else
+	bool
+#endif
+	GetWeaponSmoothSpray(void);
 	void DoStuffToGoOnFire(void);
 	bool DoesTargetHaveToBeBroken(CVector, CWeapon*);
 	void RunningLand(CPad*);


### PR DESCRIPTION
When moving and shooting with UZI and COLT45 (Only in Free Camera), the player's move direction was broken, fixed it. I took the code from VC and made some changes myself.