### PR TITLE
Fix debug script loader crashing missions

### DIFF
--- a/src/control/Script.cpp
+++ b/src/control/Script.cpp
@@ -4390,7 +4390,11 @@ CTheScripts::SwitchToMission(int32 mission)
 	CTimer::Suspend();
 	int offset = CTheScripts::MultiScriptArray[mission];
 	CFileMgr::ChangeDir("\\");
+#ifdef USE_DEBUG_SCRIPT_LOADER
+	int handle = open_script();
+#else
 	int handle = CFileMgr::OpenFile("data\\main.scm", "rb");
+#endif
 	CFileMgr::Seek(handle, offset, 0);
 	CFileMgr::Read(handle, (const char*)&CTheScripts::ScriptSpace[SIZE_MAIN_SCRIPT], SIZE_MISSION_SCRIPT);
 	CFileMgr::CloseFile(handle);

--- a/src/control/Script.cpp
+++ b/src/control/Script.cpp
@@ -1771,20 +1771,12 @@ int scriptToLoad = 0;
 
 int open_script()
 {
-	// glfwGetKey doesn't work because of CGame::Initialise is blocking
-	CPad::UpdatePads();
-	if (CPad::GetPad(0)->GetChar('G'))
-		scriptToLoad = 0;
-	if (CPad::GetPad(0)->GetChar('R'))
-		scriptToLoad = 1;
-	if (CPad::GetPad(0)->GetChar('D'))
-		scriptToLoad = 2;
 	switch (scriptToLoad) {
-	case 0: return CFileMgr::OpenFile("main.scm", "rb");
-	case 1: return CFileMgr::OpenFile("main_freeroam.scm", "rb");
-	case 2: return CFileMgr::OpenFile("main_d.scm", "rb");
+	case 0: return CFileMgr::OpenFile("data\\main.scm", "rb");
+	case 1: return CFileMgr::OpenFile("data\\main_freeroam.scm", "rb");
+	case 2: return CFileMgr::OpenFile("data\\main_d.scm", "rb");
 	}
-	return CFileMgr::OpenFile("main.scm", "rb");
+	return CFileMgr::OpenFile("data\\main.scm", "rb");
 }
 #endif
 
@@ -1800,10 +1792,16 @@ void CTheScripts::Init()
 	MissionCleanUp.Init();
 	UpsideDownCars.Init();
 	StuckCars.Init();
-	CFileMgr::SetDir("data");
 #ifdef USE_DEBUG_SCRIPT_LOADER
+	// glfwGetKey doesn't work because of CGame::Initialise is blocking
+	CPad::UpdatePads();
+	if(CPad::GetPad(0)->GetChar('G')) scriptToLoad = 0;
+	if(CPad::GetPad(0)->GetChar('R')) scriptToLoad = 1;
+	if(CPad::GetPad(0)->GetChar('D')) scriptToLoad = 2;
+
 	int mainf = open_script();
 #else
+	CFileMgr::SetDir("data");
 	int mainf = CFileMgr::OpenFile("main.scm", "rb");
 #endif
 	CFileMgr::Read(mainf, (char*)ScriptSpace, SIZE_MAIN_SCRIPT);

--- a/src/control/Script.h
+++ b/src/control/Script.h
@@ -591,5 +591,6 @@ void RetryMission(int, int);
 #endif
 
 #ifdef USE_DEBUG_SCRIPT_LOADER
+int open_script();
 extern int scriptToLoad;
 #endif

--- a/src/control/Script6.cpp
+++ b/src/control/Script6.cpp
@@ -305,7 +305,11 @@ int8 CRunningScript::ProcessCommands1000To1099(int32 command)
 		CTimer::Suspend();
 		int offset = CTheScripts::MultiScriptArray[ScriptParams[0]];
 		CFileMgr::ChangeDir("\\");
+#ifdef USE_DEBUG_SCRIPT_LOADER
+		int handle = open_script();
+#else
 		int handle = CFileMgr::OpenFile("data\\main.scm", "rb");
+#endif
 		CFileMgr::Seek(handle, offset, 0);
 		CFileMgr::Read(handle, (const char*)&CTheScripts::ScriptSpace[SIZE_MAIN_SCRIPT], SIZE_MISSION_SCRIPT);
 		CFileMgr::CloseFile(handle);


### PR DESCRIPTION
**NOTE:** I am unable to run re3 binaries I build at the moment, something something can't open HEAD.WAV.
If either Nick or riko20 could verify that these changes solve the issue, that'd be great.

* open_script is now exposed in Script.h; perhaps it should be namespaced
as a static method on CTheScripts? I'm unsure what is preferred.
* I've moved the joypad code out of open_script to prevent buttons held
  down at mission load time from changing the scriptToLoad.