### PR TITLE
Fix cmake installation with conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 set(${PROJECT}_AUDIO "OAL" CACHE STRING "Audio")
 
+option(${PROJECT}_INSTALL "Enable installation of ${EXECUTABLE} + gamefiles" OFF)
 option(${PROJECT}_WITH_OPUS "Build ${EXECUTABLE} with opus support" OFF)
 option(${PROJECT}_WITH_LIBSNDFILE "Build ${EXECUTABLE} with libsndfile (instead of internal decoder)" OFF)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -60,7 +60,7 @@ class Re3Conan(ConanFile):
             self.requires("opusfile/0.12")
 
     def export_sources(self):
-        for d in ("cmake", "src"):
+        for d in ("cmake", "gamefiles", "src"):
             shutil.copytree(src=d, dst=os.path.join(self.export_sources_folder, d))
         self.copy("CMakeLists.txt")
 


### PR DESCRIPTION
cmake installation with conan failed because the gamefiles were not copied to the source folder.

