### PR TITLE
Fix NearPed count going negative

### DIFF
--- a/src/peds/Ped.cpp
+++ b/src/peds/Ped.cpp
@@ -326,6 +326,7 @@ CPed::~CPed(void)
 					nearPed->m_nearPeds[k] = nearPed->m_nearPeds[k + 1];
 					nearPed->m_nearPeds[k + 1] = nil;
 				}
+				nearPed->m_nearPeds[ARRAY_SIZE(m_nearPeds) - 1] = nil;
 				nearPed->m_numNearPeds--;
 			} else
 				j++;


### PR DESCRIPTION
Deconstructing peds would attempt to remove themselves from their nearPeds, but would fail to remove themselves from any near peds' nearPeds list if the deconstructing ped was in the final position of nearPeds, and only decrement the near ped's numNearPeds.