### PR TITLE
Disable motion blur during cutscenes

### DIFF
--- a/src/animation/CutsceneMgr.cpp
+++ b/src/animation/CutsceneMgr.cpp
@@ -20,6 +20,7 @@
 #include "RpAnimBlend.h"
 #include "ModelIndices.h"
 #include "TempColModels.h"
+#include "postfx.h"
 
 const struct {
 	const char *szTrackName;
@@ -129,6 +130,7 @@ CAnimBlendAssocGroup CCutsceneMgr::ms_cutsceneAssociations;
 CVector CCutsceneMgr::ms_cutsceneOffset;
 float CCutsceneMgr::ms_cutsceneTimer;
 uint32 CCutsceneMgr::ms_cutsceneLoadStatus;
+bool CCutsceneMgr::ms_blurSetting;
 
 RpAtomic *
 CalculateBoundingSphereRadiusCB(RpAtomic *atomic, void *data)
@@ -232,6 +234,10 @@ CCutsceneMgr::LoadCutsceneData(const char *szCutsceneName)
 	pPlayerPed->m_fCurrentStamina = pPlayerPed->m_fMaxStamina;
 	CPad::GetPad(0)->SetDisablePlayerControls(PLAYERCONTROL_CUTSCENE);
 	CWorld::Players[CWorld::PlayerInFocus].MakePlayerSafe(true);
+
+	// save blur state and disable it
+	ms_blurSetting = CPostFX::MotionBlurOn;
+	CPostFX::MotionBlurOn = false;
 }
 
 void
@@ -363,6 +369,7 @@ CCutsceneMgr::DeleteCutsceneData(void)
 	TheCamera.SetWideScreenOff();
 	ms_running = false;
 	ms_loaded = false;
+	CPostFX::MotionBlurOn = ms_blurSetting;
 
 	FindPlayerPed()->bIsVisible = true;
 	CPad::GetPad(0)->SetEnablePlayerControls(PLAYERCONTROL_CUTSCENE);

--- a/src/animation/CutsceneMgr.h
+++ b/src/animation/CutsceneMgr.h
@@ -16,6 +16,7 @@ class CCutsceneMgr
 	static bool ms_loaded;
 	static bool ms_animLoaded;
 	static bool ms_useLodMultiplier;
+	static bool ms_blurSetting;
 
 	static char ms_cutsceneName[CUTSCENENAMESIZE];
 	static CAnimBlendAssocGroup ms_cutsceneAssociations;


### PR DESCRIPTION
This commit disable the motion blur during cutscenes - the characters animation seems too slow which results with ghosting - and restore its state afterwards.