### PR TITLE
Fix debug script loader crashing missions

### DIFF
--- a/src/control/Script.cpp
+++ b/src/control/Script.cpp
@@ -2206,24 +2206,15 @@ void CRunningScript::Init()
 
 #ifdef USE_DEBUG_SCRIPT_LOADER
 int scriptToLoad = 0;
-const char *scriptfile = "main.scm";
 
 int open_script()
 {
-	// glfwGetKey doesn't work because of CGame::Initialise is blocking 
-	CPad::UpdatePads();
-	if (CPad::GetPad(0)->GetChar('G'))
-		scriptToLoad = 0;
-	if (CPad::GetPad(0)->GetChar('R'))
-		scriptToLoad = 1;
-	if (CPad::GetPad(0)->GetChar('D'))
-		scriptToLoad = 2;
 	switch (scriptToLoad) {
-	case 0: scriptfile = "main.scm"; break;
-	case 1: scriptfile = "freeroam_miami.scm"; break;
-	case 2: scriptfile = "main_d.scm"; break;
+	case 0: return CFileMgr::OpenFile("data\\main.scm", "rb");
+	case 1: return CFileMgr::OpenFile("data\\freeroam_miami.scm", "rb");
+	case 2: return CFileMgr::OpenFile("data\\main_d.scm", "rb");
 	}
-	return CFileMgr::OpenFile(scriptfile, "rb");
+	return CFileMgr::OpenFile("data\\main.scm", "rb");
 }
 #endif
 
@@ -2239,10 +2230,16 @@ void CTheScripts::Init()
 	MissionCleanUp.Init();
 	UpsideDownCars.Init();
 	StuckCars.Init();
-	CFileMgr::SetDir("data");
 #ifdef USE_DEBUG_SCRIPT_LOADER
+	// glfwGetKey doesn't work because of CGame::Initialise is blocking
+	CPad::UpdatePads();
+	if(CPad::GetPad(0)->GetChar('G')) scriptToLoad = 0;
+	if(CPad::GetPad(0)->GetChar('R')) scriptToLoad = 1;
+	if(CPad::GetPad(0)->GetChar('D')) scriptToLoad = 2;
+
 	int mainf = open_script();
 #else
+	CFileMgr::SetDir("data");
 	int mainf = CFileMgr::OpenFile("main.scm", "rb");
 #endif
 	CFileMgr::Read(mainf, (char*)ScriptSpace, SIZE_MAIN_SCRIPT);
@@ -4839,12 +4836,10 @@ CTheScripts::SwitchToMission(int32 mission)
 #endif
 	CTimer::Suspend();
 	int offset = CTheScripts::MultiScriptArray[mission];
+	CFileMgr::ChangeDir("\\");
 #ifdef USE_DEBUG_SCRIPT_LOADER
-	CFileMgr::ChangeDir("\\data\\");
-	int handle = CFileMgr::OpenFile(scriptfile, "rb");
-	CFileMgr::ChangeDir("\\");
+	int handle = open_script();
 #else
-	CFileMgr::ChangeDir("\\");
 	int handle = CFileMgr::OpenFile("data\\main.scm", "rb");
 #endif
 	CFileMgr::Seek(handle, offset, 0);

--- a/src/control/Script.h
+++ b/src/control/Script.h
@@ -597,5 +597,6 @@ void RetryMission(int, int);
 #endif
 
 #ifdef USE_DEBUG_SCRIPT_LOADER
+int open_script();
 extern int scriptToLoad;
 #endif

--- a/src/control/Script6.cpp
+++ b/src/control/Script6.cpp
@@ -383,12 +383,10 @@ int8 CRunningScript::ProcessCommands1000To1099(int32 command)
 #endif
 		CTimer::Suspend();
 		int offset = CTheScripts::MultiScriptArray[ScriptParams[0]];
+		CFileMgr::ChangeDir("\\");
 #ifdef USE_DEBUG_SCRIPT_LOADER
-		CFileMgr::ChangeDir("\\data\\");
-		int handle = CFileMgr::OpenFile(scriptfile, "rb");
-		CFileMgr::ChangeDir("\\");
+		int handle = open_script();
 #else
-		CFileMgr::ChangeDir("\\");
 		int handle = CFileMgr::OpenFile("data\\main.scm", "rb");
 #endif
 		CFileMgr::Seek(handle, offset, 0);


### PR DESCRIPTION
See also: #1217 (re3)

This is a draft because I think `miami` branch's debug script loader was already functional entirely off the back of the `scriptFile` global being used properly.

I'd like to finish looking into pole dropping before returning to this