### PR TITLE
Fix bug triggering gnNumTempPedList assertion

### DIFF
--- a/src/peds/Ped.cpp
+++ b/src/peds/Ped.cpp
@@ -392,8 +392,21 @@ CPed::BuildPedLists(void)
 					if (ped != this && !ped->bInVehicle) {
 						float dist = (ped->GetPosition() - GetPosition()).Magnitude2D();
 						if (nThreatReactionRangeMultiplier * 30.0f > dist) {
+#ifdef FIX_BUGS
+							static_assert( ARRAY_SIZE(m_nearPeds) < ARRAY_SIZE(gapTempPedList) - 1, "gapTempPedList needs wiggle room for unsorted peds and nil slot" );
+							// If the gap ped list is full, sort it and truncate it
+							// before pushing more unsorted peds
+							if( gnNumTempPedList == ARRAY_SIZE(gapTempPedList) - 1 )
+							{
+								gapTempPedList[gnNumTempPedList] = nil;
+								SortPeds(gapTempPedList, 0, gnNumTempPedList - 1);
+								gnNumTempPedList = ARRAY_SIZE(m_nearPeds);
+							}
+#endif
+
 							gapTempPedList[gnNumTempPedList] = ped;
 							gnNumTempPedList++;
+							// NOTE: We cannot absolutely fill the gap list, as the list is null-terminated before being passed to SortPeds
 							assert(gnNumTempPedList < ARRAY_SIZE(gapTempPedList));
 						}
 					}

--- a/src/peds/Ped.cpp
+++ b/src/peds/Ped.cpp
@@ -393,7 +393,6 @@ CPed::BuildPedLists(void)
 						float dist = (ped->GetPosition() - GetPosition()).Magnitude2D();
 						if (nThreatReactionRangeMultiplier * 30.0f > dist) {
 #ifdef FIX_BUGS
-							static_assert( ARRAY_SIZE(m_nearPeds) < ARRAY_SIZE(gapTempPedList) - 1, "gapTempPedList needs wiggle room for unsorted peds and nil slot" );
 							// If the gap ped list is full, sort it and truncate it
 							// before pushing more unsorted peds
 							if( gnNumTempPedList == ARRAY_SIZE(gapTempPedList) - 1 )


### PR DESCRIPTION
This solves the gnNumTempPedList assertion.
To prove this works, change gapTempPedList's length to 11, and visit the Triad's basketball court.

This change allows the near sectors to have more peds than the gap-list can contain by truncating the gap-list to the nearest `ARRAY_SIZE(m_nearPeds)` peds in the peds seen-so-far, rather than only sorting and truncating after all peds have been visited.

Additionally, the gnNumTempPedList assert previously was oversensitive, considering a full list after pushing to be an error condition. (It's only an error to try and push to a full list)